### PR TITLE
feat: change logo container to ancher element

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,11 +41,11 @@ export default function App() {
   const { onTouchStart, onTouchEnd } = useTouchEvents(ref);
   let startX = 0;
 
-  onTouchStart((event) => {
+  onTouchStart((event: TouchEvent) => {
     startX = event.touches[0].clientX;
   });
 
-  onTouchEnd((event) => {
+  onTouchEnd((event: TouchEvent) => {
     if (startX / window.innerWidth > 0.1) return;
 
     const endX = event.changedTouches[0].clientX;

--- a/src/components/Shell/Header/Logo.tsx
+++ b/src/components/Shell/Header/Logo.tsx
@@ -2,7 +2,17 @@ import { Flex, Image, Text } from '@mantine/core'
 
 export default function Logo() {
   return (
-    <Flex id="logo" align="center" gap="xs">
+    <Flex
+      component="a"
+      id="logo"
+      href="/"
+      style={{
+        color: 'black',
+        textDecoration: 'none',
+      }}
+      align="center"
+      gap="xs"
+    >
       <Image alt="logo" src="/favicon.webp" w={32} h={32} />
       <Text fw="bold" fz="lg" style={{
         overflow: 'hidden',


### PR DESCRIPTION
在移动端，返回首页需要先打开侧边栏再点击按钮，但是在网页设计中，Logo 一般是指向首页的。