### PR TITLE
refactor: adopt ts-pattern and clean up lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "shiki": "3.23.0",
     "stylelint": "16.26.1",
     "stylelint-config-standard-scss": "13.1.0",
+    "ts-pattern": "^5.9.0",
     "vike": "0.4.257",
     "vike-react": "0.6.21",
     "wanakana": "5.3.1",

--- a/src/components/Alias/AliasModal.tsx
+++ b/src/components/Alias/AliasModal.tsx
@@ -31,6 +31,7 @@ import useFixedGame from "@/hooks/useFixedGame.ts";
 import useSongListStore from "@/hooks/useSongListStore.ts";
 import { useShallow } from "zustand/react/shallow";
 import { AliasProps } from "@/types/alias";
+import { match, P } from "ts-pattern";
 
 interface AliasModalProps {
   alias: AliasProps;
@@ -75,7 +76,11 @@ export function calculateNewAliasWeight(
     } // 改为支持
   }
 
-  const newWeight = current === (isUpvote ? 1 : -1) ? 0 : isUpvote ? 1 : -1;
+  const newWeight = match([current, isUpvote] as const)
+    .with([1, true], () => 0)
+    .with([-1, false], () => 0)
+    .with([P._, true], () => 1)
+    .otherwise(() => -1);
 
   return {
     ...alias,

--- a/src/components/Scores/AdvancedFilter.tsx
+++ b/src/components/Scores/AdvancedFilter.tsx
@@ -24,6 +24,7 @@ import useSongListStore from "@/hooks/useSongListStore.ts";
 import { ChunithmScoreProps, MaimaiScoreProps } from "@/types/score";
 import useGame from "@/hooks/useGame.ts";
 import { useScoreFilters } from "@/hooks/useScoreFilters.ts";
+import { match, P } from "ts-pattern";
 
 const filterData = {
   maimai: {
@@ -580,7 +581,10 @@ export const AdvancedFilter = ({
                 options={[
                   { value: "0", label: "无" },
                   ...[1, 2, 3, 4, 5].map((count) => {
-                    const rate = count <= 2 ? 1 : count <= 4 ? 2 : 3;
+                    const rate = match(count)
+                      .with(P.number.lte(2), () => 1)
+                      .with(P.number.lte(4), () => 2)
+                      .otherwise(() => 3);
                     return {
                       value: count.toString(),
                       label: (

--- a/src/components/Shell/Header/ColorSchemeToggle.tsx
+++ b/src/components/Shell/Header/ColorSchemeToggle.tsx
@@ -1,5 +1,6 @@
 import { ActionIcon, Group, rem, Tooltip, useMantineColorScheme } from "@mantine/core";
 import { IconMoonStars, IconSun, IconSunMoon } from "@tabler/icons-react";
+import { match } from "ts-pattern";
 
 const colorSchemes = {
   auto: {
@@ -30,7 +31,11 @@ export const ColorSchemeToggle = () => {
           size={rem(32)}
           onClick={() =>
             setColorScheme(
-              colorScheme === "auto" ? "dark" : colorScheme === "dark" ? "light" : "auto",
+              match(colorScheme)
+                .with("auto", () => "dark" as const)
+                .with("dark", () => "light" as const)
+                .with("light", () => "auto" as const)
+                .exhaustive(),
             )
           }
           color={colorSchemes[colorScheme].color}

--- a/src/hooks/queries/queryFn.ts
+++ b/src/hooks/queries/queryFn.ts
@@ -12,24 +12,28 @@ async function parseJSON<T>(res: Response): Promise<T> {
 }
 
 // 用于返回 { success, data } 包装格式的 API 端点（大部分 /user/* 端点）
-export const defaultQueryFn = async ({ queryKey }: QueryFunctionContext) => {
+export const defaultQueryFn = async <T = unknown>({
+  queryKey,
+}: QueryFunctionContext): Promise<T> => {
   const url = queryKey[0] as string;
   const res = await fetchAPI(url, { method: "GET" });
-  const data = await parseJSON<ApiResponse<any>>(res);
+  const data = await parseJSON<ApiResponse<T>>(res);
   if (!data.success) {
     throw new APIError(data.message, { status: res.status, code: data.code });
   }
-  return data.data;
+  return data.data as T;
 };
 
 // 用于直接返回数据的 API 端点（如公开的 /{game}/song/* 端点），通过 HTTP 状态码判断错误
-export const resourceQueryFn = async ({ queryKey }: QueryFunctionContext) => {
+export const resourceQueryFn = async <T = unknown>({
+  queryKey,
+}: QueryFunctionContext): Promise<T> => {
   const url = queryKey[0] as string;
   const res = await fetchAPI(url, { method: "GET" });
-  const data = await parseJSON<any>(res);
+  const data = await parseJSON<unknown>(res);
   if (!res.ok) {
     const error = data as ApiResponse;
     throw new APIError(error.message, { status: res.status, code: error.code });
   }
-  return data;
+  return data as T;
 };

--- a/src/hooks/queries/queryFn.ts
+++ b/src/hooks/queries/queryFn.ts
@@ -21,7 +21,7 @@ export const defaultQueryFn = async <T = unknown>({
   if (!data.success) {
     throw new APIError(data.message, { status: res.status, code: data.code });
   }
-  return data.data as T;
+  return data.data;
 };
 
 // 用于直接返回数据的 API 端点（如公开的 /{game}/song/* 端点），通过 HTTP 状态码判断错误

--- a/src/pages/public/Chart/components/NoteCountGraph/NoteCountGraph.tsx
+++ b/src/pages/public/Chart/components/NoteCountGraph/NoteCountGraph.tsx
@@ -1,16 +1,9 @@
 import { useCallback, useMemo, useRef, useEffect } from "react";
 import { useGameStore, playbackTimeRef } from "../../stores/useGameStore";
-import {
-  Note,
-  BpmEvent,
-  isTapNote,
-  isHoldStartNote,
-  isSlideNote,
-  isTouchNote,
-  isTouchHoldStartNote,
-} from "../../types";
+import { Note, BpmEvent } from "../../types";
 import classes from "./NoteCountGraph.module.css";
 import clsx from "clsx";
+import { match, P } from "ts-pattern";
 
 interface NoteCountData {
   tap: number;
@@ -92,21 +85,18 @@ function calculateNoteCounts(notes: Note[], totalDurationMs: number): NoteCountD
 
     const bucket = buckets[bucketIndex];
 
-    if (isTapNote(note)) {
-      if (note.type === "break") {
-        bucket.break++;
-      } else {
-        bucket.tap++;
-      }
-      bucket.total++;
-    } else if (isHoldStartNote(note)) {
-      bucket.hold++;
-      bucket.total++;
-    } else if (isSlideNote(note)) {
-      bucket.slide++;
-      bucket.total++;
-    } else if (isTouchNote(note) || isTouchHoldStartNote(note)) {
-      bucket.touch++;
+    const bucketKey = match(note.type)
+      .returnType<"tap" | "hold" | "slide" | "touch" | "break" | null>()
+      .with("break", () => "break")
+      .with(P.union("tap", "simultaneous"), () => "tap")
+      .with(P.union("hold-start", "hold-start-simultaneous"), () => "hold")
+      .with("slide", () => "slide")
+      .with(P.union("touch", "touch-hold-start"), () => "touch")
+      .with(P.union("hold-end", "hold-end-simultaneous", "touch-hold-end"), () => null)
+      .exhaustive();
+
+    if (bucketKey) {
+      bucket[bucketKey]++;
       bucket.total++;
     }
   }
@@ -533,7 +523,10 @@ export function NoteCountGraph({ fullscreen }: { fullscreen?: boolean }) {
                 )}
                 style={{
                   left: `${percent}%`,
-                  height: isMajor ? "6px" : isMedium ? "4px" : "2px",
+                  height: match([isMajor, isMedium] as const)
+                    .with([true, P._], () => "6px")
+                    .with([false, true], () => "4px")
+                    .otherwise(() => "2px"),
                 }}
               />
             );

--- a/src/pages/public/Chart/core/audio/AudioManager.ts
+++ b/src/pages/public/Chart/core/audio/AudioManager.ts
@@ -1,5 +1,6 @@
 import { Note, AudioConfig } from "../../types";
 import { ANSWER_SOUND_BASE_OFFSET_MS } from "../../utils/constants";
+import { match, P } from "ts-pattern";
 
 const SCHEDULE_LOOKAHEAD_MS = 1500;
 
@@ -117,29 +118,30 @@ export class AudioManager {
   }
 
   private shouldPlaySound(note: Note): boolean {
-    switch (note.type) {
-      case "tap":
-      case "break":
-      case "simultaneous":
-      case "hold-start":
-      case "hold-start-simultaneous":
-      case "slide":
-        return note.type !== "slide" || !note.isHeadless;
-
-      case "touch":
-      case "touch-hold-start":
-        return this.touchSoundEnabled;
-
-      case "touch-hold-end":
-        return this.touchSoundEnabled && this.holdEndSoundEnabled;
-
-      case "hold-end":
-      case "hold-end-simultaneous":
-        return this.holdEndSoundEnabled;
-
-      default:
-        return false;
-    }
+    return match(note)
+      .with({ type: "slide" }, (n) => !n.isHeadless)
+      .with(
+        {
+          type: P.union(
+            "tap",
+            "break",
+            "simultaneous",
+            "hold-start",
+            "hold-start-simultaneous",
+          ),
+        },
+        () => true,
+      )
+      .with({ type: P.union("touch", "touch-hold-start") }, () => this.touchSoundEnabled)
+      .with(
+        { type: "touch-hold-end" },
+        () => this.touchSoundEnabled && this.holdEndSoundEnabled,
+      )
+      .with(
+        { type: P.union("hold-end", "hold-end-simultaneous") },
+        () => this.holdEndSoundEnabled,
+      )
+      .exhaustive();
   }
 
   private getEventKey(note: Note): string {

--- a/src/pages/public/Chart/core/audio/AudioManager.ts
+++ b/src/pages/public/Chart/core/audio/AudioManager.ts
@@ -122,25 +122,13 @@ export class AudioManager {
       .with({ type: "slide" }, (n) => !n.isHeadless)
       .with(
         {
-          type: P.union(
-            "tap",
-            "break",
-            "simultaneous",
-            "hold-start",
-            "hold-start-simultaneous",
-          ),
+          type: P.union("tap", "break", "simultaneous", "hold-start", "hold-start-simultaneous"),
         },
         () => true,
       )
       .with({ type: P.union("touch", "touch-hold-start") }, () => this.touchSoundEnabled)
-      .with(
-        { type: "touch-hold-end" },
-        () => this.touchSoundEnabled && this.holdEndSoundEnabled,
-      )
-      .with(
-        { type: P.union("hold-end", "hold-end-simultaneous") },
-        () => this.holdEndSoundEnabled,
-      )
+      .with({ type: "touch-hold-end" }, () => this.touchSoundEnabled && this.holdEndSoundEnabled)
+      .with({ type: P.union("hold-end", "hold-end-simultaneous") }, () => this.holdEndSoundEnabled)
       .exhaustive();
   }
 

--- a/src/pages/public/Chart/core/parser/ChartParser.ts
+++ b/src/pages/public/Chart/core/parser/ChartParser.ts
@@ -549,8 +549,14 @@ function parseNoteString(
       pathStartIndex >= 0 ? slideNotation.slice(0, pathStartIndex).toLowerCase() : "";
     // simai 无头滑条：`?` 让 tracing star 渐显，`!` 让 tracing star 在滑条启动时突然出现。
     const headlessMarker = match(startModifiers)
-      .when((s) => s.includes("!"), () => "!" as const)
-      .when((s) => s.includes("?"), () => "?" as const)
+      .when(
+        (s) => s.includes("!"),
+        () => "!" as const,
+      )
+      .when(
+        (s) => s.includes("?"),
+        () => "?" as const,
+      )
       .otherwise(() => null);
     const isStartBreak = startModifiers.includes("b");
     const isHeadless = headlessMarker !== null;

--- a/src/pages/public/Chart/core/parser/ChartParser.ts
+++ b/src/pages/public/Chart/core/parser/ChartParser.ts
@@ -1,3 +1,4 @@
+import { match } from "ts-pattern";
 import {
   Chart,
   ChartMetadata,
@@ -56,7 +57,7 @@ export function parseSimaiChart(simaiText: string, difficulty?: ChartDifficulty)
     throw new Error("Invalid input: expected a non-empty string");
   }
 
-  if (!/[0-9,\(\)\{\}\/\n&\-><^vpqszVwhb\[\]:\.=\s]/.test(simaiText)) {
+  if (!/[0-9,(){}/\n&\-><^vpqszVwhb[\]:.=\s]/.test(simaiText)) {
     throw new Error("Invalid simai format: expected digits, commas, brackets, and note markers");
   }
 
@@ -547,11 +548,10 @@ function parseNoteString(
     const startModifiers =
       pathStartIndex >= 0 ? slideNotation.slice(0, pathStartIndex).toLowerCase() : "";
     // simai 无头滑条：`?` 让 tracing star 渐显，`!` 让 tracing star 在滑条启动时突然出现。
-    const headlessMarker = startModifiers.includes("!")
-      ? "!"
-      : startModifiers.includes("?")
-        ? "?"
-        : null;
+    const headlessMarker = match(startModifiers)
+      .when((s) => s.includes("!"), () => "!" as const)
+      .when((s) => s.includes("?"), () => "?" as const)
+      .otherwise(() => null);
     const isStartBreak = startModifiers.includes("b");
     const isHeadless = headlessMarker !== null;
     const isEx = /x/i.test(noteStr);
@@ -666,7 +666,11 @@ function parseNoteString(
         scale: 1,
         bpm,
         isHeadless,
-        headlessMode: headlessMarker === "!" ? "pop" : headlessMarker === "?" ? "fade" : undefined,
+        headlessMode: match(headlessMarker)
+          .with("!", () => "pop" as const)
+          .with("?", () => "fade" as const)
+          .with(null, () => undefined)
+          .exhaustive(),
         isStartBreak,
         allSlideBreaks,
         isEx,

--- a/src/pages/public/Chart/renderers/HoldRenderer.ts
+++ b/src/pages/public/Chart/renderers/HoldRenderer.ts
@@ -1,6 +1,5 @@
 import { BaseRenderer, RenderContext } from "./BaseRenderer";
 import { HoldStartNote, HoldEndNote, NoteRenderPosition, ButtonPosition, Point2D } from "../types";
-import { NoteRenderer } from "./NoteRenderer";
 import {
   NOTE_SIZE_RATIO,
   HOLD_WIDTH_RATIO,
@@ -11,7 +10,7 @@ import {
 } from "../utils/constants";
 
 export class HoldRenderer extends BaseRenderer {
-  constructor(context: RenderContext, _noteRenderer: NoteRenderer) {
+  constructor(context: RenderContext) {
     super(context);
   }
 

--- a/src/pages/public/Chart/renderers/MainRenderer.ts
+++ b/src/pages/public/Chart/renderers/MainRenderer.ts
@@ -138,7 +138,7 @@ export class MainRenderer {
 
     this.noteRenderer = new NoteRenderer(context);
     this.slideRenderer = new SlideRenderer(context, this.noteRenderer);
-    this.holdRenderer = new HoldRenderer(context, this.noteRenderer);
+    this.holdRenderer = new HoldRenderer(context);
     this.touchRenderer = new TouchRenderer(context);
   }
 

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -5,7 +5,7 @@ export const validateEmail = (email: string, { allowEmpty = false }) => {
     return null;
   }
   if (
-    !/^([a-zA-Z0-9])(([a-zA-Z0-9])*([._-])?([a-zA-Z0-9]))*@(([a-zA-Z0-9\-])+(\.))+([a-zA-Z]{2,4})+$/.test(
+    !/^([a-zA-Z0-9])(([a-zA-Z0-9])*([._-])?([a-zA-Z0-9]))*@(([a-zA-Z0-9-])+(\.))+([a-zA-Z]{2,4})+$/.test(
       email,
     )
   ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5438,6 +5438,7 @@ __metadata:
     shiki: "npm:3.23.0"
     stylelint: "npm:16.26.1"
     stylelint-config-standard-scss: "npm:13.1.0"
+    ts-pattern: "npm:^5.9.0"
     typescript: "npm:5.9.3"
     vike: "npm:0.4.257"
     vike-react: "npm:0.6.21"
@@ -8672,6 +8673,13 @@ __metadata:
   version: 0.2.0
   resolution: "ts-easing@npm:0.2.0"
   checksum: 10c0/84ec20192310c697ff890ca2e0625e131a32596a7c5956326c9632faca9037abf2dd3de4d81ac358ae9f26a6a2cfe2300f13756b26995f753d882e3d0463e327
+  languageName: node
+  linkType: hard
+
+"ts-pattern@npm:^5.9.0":
+  version: 5.9.0
+  resolution: "ts-pattern@npm:5.9.0"
+  checksum: 10c0/7640db25c39d29b287471b2b82d4f7b4674a02098c6ba4d10fed180adfb07d0e0c71930d9e59dc0d90654145e02fd320af63cf0df3c41e100d4154658a612a0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- 用 [`ts-pattern`](https://github.com/gvergnaud/ts-pattern) 的 `match()` 重写 8 处嵌套三元 / type-guard if-else 链；其中 4 处带 `.exhaustive()`，未来增删 Note 类型时 TS 会强制覆盖
- 清零项目里所有 11 个 ESLint 错误（正则多余转义、未使用参数、`any` 泄漏）
- 把 `defaultQueryFn` / `resourceQueryFn` 改成 `<T = unknown>` 泛型；20 个 `useQuery<T>` 调用点自动推断 T，零破坏面

## Test plan

- [x] `yarn tsc --noEmit` 通过（rebase on top of #30 之后）
- [x] `yarn eslint` 错误数 11 → 0（80 个 warning 全是预先存在的 `react-hooks/exhaustive-deps`）
- [x] 正则改动前后用 Node 跨 0x00–0xFF 所有码点 + 邮箱样本验证字符匹配集合不变
- [ ] 浏览器手动测试谱面渲染、颜色主题切换、分数过滤等关联 UI（建议合并前过一遍）

## 改动详情

### ts-pattern 重写

| 位置 | 改动 |
|------|------|
| `ColorSchemeToggle.tsx` | `colorScheme` 三态轮换 → `.exhaustive()` |
| `ChartParser.ts` | `headlessMarker` 检测 + `headlessMode` 派发 |
| `AliasModal.tsx` | `calculateNewAliasWeight` 的复合派发用元组模式 |
| `AdvancedFilter.tsx` | DX 星级 rate 用 `P.number.lte` 分桶 |
| `NoteCountGraph.tsx` | 刻度高度 + `calculateNoteCounts` 的 bucket 派发（11 种 Note 类型全覆盖） |
| `AudioManager.ts` | `shouldPlaySound` switch → `.exhaustive()`，slide 特殊逻辑独立成支 |

### Lint 修复

- `ChartParser.ts:60` / `validator.ts:8`：删除字符类内多余转义（`\(\)\{\}\/\[\.` 等），保留 load-bearing 的 `\-`（在 `&` 和 `>` 之间防止被解释为范围）
- `HoldRenderer.ts`：删除未用的 `_noteRenderer` 构造器参数 + `NoteRenderer` import，同步更新 `MainRenderer.ts` 的调用点
- `queryFn.ts`：`defaultQueryFn` / `resourceQueryFn` 改泛型 `<T = unknown>`，消除 `any`

🤖 Generated with [Claude Code](https://claude.com/claude-code)