### PR TITLE
fix(captcha): 优化时间相关人机验证错误提示

### DIFF
--- a/src/utils/captcha.ts
+++ b/src/utils/captcha.ts
@@ -6,6 +6,19 @@ const CAP_SOLVE_TIMEOUT = 60000;
 
 let scriptPromise: Promise<void> | null = null;
 
+// cap.js 的挑战/令牌带有过期时间，校验依赖客户端系统时钟。
+// 当设备时间不准（如双系统未同步、未开启 NTP）时，服务端会返回类似
+// "invalid expiration time" 的错误，对用户而言难以理解。这里将这类
+// 时间相关错误转换为更明确的提示。
+export function friendlyCaptchaError(message?: string): string {
+  const fallback = "人机验证失败，请刷新页面后重试";
+  if (!message) return fallback;
+  if (/expir|invalid.*time|time.*invalid|clock|timestamp/i.test(message)) {
+    return "人机验证失败，可能是设备系统时间不准，请校准时间（开启自动同步）后重试";
+  }
+  return message;
+}
+
 function loadCapScript(): Promise<void> {
   if (scriptPromise) return scriptPromise;
   scriptPromise = new Promise((resolve, reject) => {
@@ -34,7 +47,7 @@ export async function solveCaptcha(): Promise<string> {
     const result = await Promise.race([
       new Promise<never>((_, reject) => {
         cap.addEventListener("error", (event) => {
-          reject(new Error(event.detail?.message || "人机验证失败，请刷新页面后重试"));
+          reject(new Error(friendlyCaptchaError(event.detail?.message)));
         });
       }),
       cap.solve(),


### PR DESCRIPTION
## 背景

有用户（Linux 环境）登录时遇到 `Error: invalid expiration time`，且为个例。

排查结论：

- 该文案 **不在前端代码中**，前端只是转发显示。
- 登录流程在调用登录接口前会先执行 `solveCaptcha()`（`@cap.js/widget`，服务端 `cap.lxns.net`）。cap.js 的挑战/令牌带有过期时间，校验依赖**客户端系统时钟**。
- 弹窗前缀是纯 `Error:`（而非登录接口的 `APIError:`），对应 `src/utils/captcha.ts` 中 `error` 事件 `reject(new Error(event.detail?.message))` 的写法。
- 个例 + Linux 的典型成因是**设备系统时间不准**（双系统未同步硬件时钟、未开启 NTP 等），导致 captcha 令牌被服务端判定为时间非法/过期。

因此这既不是登录后端的 bug，也不是前端逻辑 bug，但 `invalid expiration time` 原文对用户而言难以理解。

## 改动

- 新增 `friendlyCaptchaError(message)`：对过期/时间相关的 captcha 错误（匹配 `expir`、`invalid time`、`clock`、`timestamp` 等关键词）返回更明确的中文引导——提示用户校准系统时间（开启自动同步）后重试；其余错误保持原样透传。
- `solveCaptcha` 的 `error` 事件处理改为经由该函数生成提示。

仅影响 `src/utils/captcha.ts`，不改变正常验证流程。

## 测试建议

- 正常 captcha 流程不受影响。
- 当 captcha 返回 `invalid expiration time` 等时间类错误时，登录弹窗显示新的中文引导文案。

https://claude.ai/code/session_01Y5YoDdoRfyhZhhETiA73GY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5YoDdoRfyhZhhETiA73GY)_