### PR TITLE
fix(collections): guard optional required.difficulties

### DIFF
--- a/src/components/Collections/RequiredSong.tsx
+++ b/src/components/Collections/RequiredSong.tsx
@@ -58,7 +58,7 @@ const RequiredSongRingProgress = ({ collection }: { collection: CollectionProps 
     let completed = 0;
     (collection.required || []).forEach((required) => {
       (required.songs || []).forEach((song) => {
-        total += required.difficulties.length;
+        total += (required.difficulties || []).length;
         completed += (song.completed_difficulties || []).length;
       });
     });
@@ -111,7 +111,7 @@ export const RequiredSong = ({
   useEffect(() => {
     setPage(1);
     if (collection && collection.required) {
-      setDifficulties(collection.required.map((required) => required.difficulties).flat());
+      setDifficulties(collection.required.map((required) => required.difficulties || []).flat());
     }
   }, [collection]);
 
@@ -126,7 +126,7 @@ export const RequiredSong = ({
         return (
           collection.required &&
           collection.required.every((required) => {
-            if (required.difficulties.includes(difficulty || 0)) {
+            if ((required.difficulties || []).includes(difficulty || 0)) {
               return (required.songs || []).some((song) => {
                 return song.title === record.title && song.type === record.type;
               });
@@ -160,7 +160,7 @@ export const RequiredSong = ({
   const difficultyProgress = (collection.required || []).reduce(
     (acc, req) => {
       if (difficulty === undefined) return acc;
-      if (!(req.difficulties || []).includes(difficulty) && req.difficulties.length != 0)
+      if (!(req.difficulties || []).includes(difficulty) && (req.difficulties || []).length != 0)
         return acc;
 
       const songsTotal = (req.songs || []).length;

--- a/src/types/player.d.ts
+++ b/src/types/player.d.ts
@@ -49,7 +49,7 @@ export interface CollectionRequiredSongProps {
 
 interface CollectionRequiredProps {
   completed: boolean;
-  difficulties: number[];
+  difficulties?: number[];
   // maimai
   fc: string;
   fs: string;


### PR DESCRIPTION
Found while verifying the frontend↔backend integration for the backend audit fixes.

The collection-progress API serializes `Difficulties *[]int` with `omitempty`, so a required entry whose `difficulties` is nil comes back **with the field absent** → `undefined` at runtime. But `CollectionRequiredProps.difficulties` was typed as a required `number[]`, and four sites read it unguarded (`required.difficulties.length` / `.includes(...)`), which would throw `Cannot read properties of undefined`.

This was previously **masked** because the backend *panicked* (500) on a nil `difficulties`, so the frontend never received such a response. The backend fix (Lxns-Network/maimai-prober#40 / issue #39) now returns the data gracefully — so the frontend must handle the absent field.

- `difficulties` → optional in `CollectionRequiredProps` (matches the API's `omitempty`)
- guarded all 4 accesses in `RequiredSong.tsx` with `|| []` (`tsc` surfaced the two I'd have missed)

`npx tsc --noEmit` clean.