### PR TITLE
feat(notification): 通知中心（前端）

### DIFF
--- a/src/components/FilterChips.tsx
+++ b/src/components/FilterChips.tsx
@@ -1,0 +1,33 @@
+import { Chip, Flex, Text } from "@mantine/core";
+import { ReactNode } from "react";
+
+export interface FilterChipsOption {
+  value: string;
+  label: ReactNode;
+}
+
+interface FilterChipsProps {
+  title: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  options: FilterChipsOption[];
+}
+
+export const FilterChips = ({ title, value, onChange, options }: FilterChipsProps) => {
+  return (
+    <div>
+      <Text fz="xs" c="dimmed" mb={3}>
+        {title}
+      </Text>
+      <Flex rowGap="xs" columnGap="md" wrap="wrap">
+        <Chip.Group multiple value={value} onChange={onChange}>
+          {options.map((opt) => (
+            <Chip key={opt.value} variant="filled" size="xs" value={opt.value}>
+              {opt.label}
+            </Chip>
+          ))}
+        </Chip.Group>
+      </Flex>
+    </div>
+  );
+};

--- a/src/components/Notifications/NotificationTypeIcon.tsx
+++ b/src/components/Notifications/NotificationTypeIcon.tsx
@@ -1,0 +1,31 @@
+import { Indicator, ThemeIcon } from "@mantine/core";
+import { getNotificationTypeIcon } from "./notificationIcons.ts";
+
+const levelColor: Record<string, string> = {
+  normal: "gray",
+  important: "yellow",
+  urgent: "red",
+};
+
+interface NotificationTypeIconProps {
+  type: string;
+  level: string;
+  unread?: boolean;
+}
+
+export function NotificationTypeIcon({ type, level, unread }: NotificationTypeIconProps) {
+  const Icon = getNotificationTypeIcon(type);
+  const themeIcon = (
+    <ThemeIcon variant="light" radius="xl" color={levelColor[level] ?? "gray"}>
+      <Icon size={16} />
+    </ThemeIcon>
+  );
+
+  if (unread === undefined) return themeIcon;
+
+  return (
+    <Indicator color="red" size={8} offset={4} disabled={!unread}>
+      {themeIcon}
+    </Indicator>
+  );
+}

--- a/src/components/Notifications/PublishNotificationModal.tsx
+++ b/src/components/Notifications/PublishNotificationModal.tsx
@@ -10,6 +10,7 @@ import {
   ScrollArea,
   Select,
   Stack,
+  Switch,
   Text,
   TextInput,
 } from "@mantine/core";
@@ -57,6 +58,7 @@ interface FormValues {
   type: string;
   expire: string | null;
   audience: PublishNotificationPayload["audience"];
+  persistent: boolean;
 }
 
 export function PublishNotificationModal({
@@ -82,6 +84,7 @@ export function PublishNotificationModal({
       type: "general",
       expire: null,
       audience: { type: "all" },
+      persistent: false,
     },
     validate: { title: (v) => (v.trim() === "" ? "标题不能为空" : null) },
   });
@@ -129,6 +132,7 @@ export function PublishNotificationModal({
             : editing.audience_type === "users"
               ? { type: "users", user_ids: [] }
               : { type: "all" },
+        persistent: editing.persistent,
       });
       editor?.commands.setContent(editing.content || "");
     } else {
@@ -158,6 +162,7 @@ export function PublishNotificationModal({
       type: values.type,
       level: values.level,
       audience: values.audience,
+      persistent: values.persistent,
       expire_time: values.expire ? dayjs(values.expire).toISOString() : undefined,
     };
 
@@ -283,6 +288,14 @@ export function PublishNotificationModal({
               );
             })}
         </Group>
+        {!lockedUserIds && editing?.audience_type !== "users" && (
+          <Switch
+            label="常驻通知"
+            description="发布后才注册的新用户也能看到，适合欢迎、规则等 onboarding 公告。"
+            mb="xs"
+            {...form.getInputProps("persistent", { type: "checkbox" })}
+          />
+        )}
         <DatesProvider settings={{ locale: "zh-cn", firstDayOfWeek: 0, weekendDays: [0, 6] }}>
           <DateTimePicker
             label="过期时间（可选）"

--- a/src/components/Notifications/PublishNotificationModal.tsx
+++ b/src/components/Notifications/PublishNotificationModal.tsx
@@ -1,0 +1,335 @@
+import { useEffect } from "react";
+import { useForm } from "@mantine/form";
+import {
+  Button,
+  Chip,
+  Group,
+  Input,
+  Modal,
+  MultiSelect,
+  ScrollArea,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { DatesProvider, DateTimePicker } from "@mantine/dates";
+import { useFileDialog } from "@mantine/hooks";
+import { useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { Underline } from "@tiptap/extension-underline";
+import { Link, RichTextEditor } from "@mantine/tiptap";
+import { Image } from "@tiptap/extension-image";
+import { Highlight } from "@tiptap/extension-highlight";
+import { TextAlign } from "@tiptap/extension-text-align";
+import { IconPhoto } from "@tabler/icons-react";
+import dayjs from "dayjs";
+import "dayjs/locale/zh-cn";
+import { useBackDismiss } from "@/hooks/useBackDismiss.ts";
+import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import {
+  usePublishNotification,
+  useUpdateNotification,
+  useUploadNotificationImage,
+} from "@/hooks/mutations/useAdminNotificationMutations.ts";
+import { AdminBroadcast, PublishNotificationPayload } from "@/types/notification";
+import { listToPermission, permissionToList, UserPermission } from "@/utils/session.ts";
+import { getNotificationTypeIcon } from "@/components/Notifications/notificationIcons.ts";
+import { match, P } from "ts-pattern";
+
+const PERMISSION_OPTIONS = [
+  { label: "普通用户", value: UserPermission.User.toString() },
+  { label: "开发者", value: UserPermission.Developer.toString() },
+  { label: "管理员", value: UserPermission.Administrator.toString() },
+];
+
+const TYPE_OPTIONS = [
+  { value: "general", label: "普通" },
+  { value: "maintenance", label: "维护" },
+  { value: "version", label: "版本更新" },
+  { value: "event", label: "活动" },
+  { value: "developer", label: "开发者" },
+];
+
+interface FormValues {
+  title: string;
+  level: PublishNotificationPayload["level"];
+  type: string;
+  expire: string | null;
+  audience: PublishNotificationPayload["audience"];
+}
+
+export function PublishNotificationModal({
+  opened,
+  onClose,
+  editing,
+  lockedUserIds,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  editing?: AdminBroadcast;
+  // 由用户列表「发送通知」传入：受众锁定为这些用户，Modal 内不再选择受众。
+  lockedUserIds?: number[];
+}) {
+  useBackDismiss(opened, onClose);
+  const { mutate: publish } = usePublishNotification();
+  const { mutate: update } = useUpdateNotification();
+
+  const form = useForm<FormValues>({
+    initialValues: {
+      title: "",
+      level: "normal",
+      type: "general",
+      expire: null,
+      audience: { type: "all" },
+    },
+    validate: { title: (v) => (v.trim() === "" ? "标题不能为空" : null) },
+  });
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Underline,
+      Link,
+      Image.configure({ HTMLAttributes: { style: "max-width: 100%;" } }),
+      Highlight,
+      TextAlign.configure({ types: ["heading", "paragraph"] }),
+    ],
+    content: "",
+  });
+
+  const { mutate: uploadImage } = useUploadNotificationImage();
+  const imageDialog = useFileDialog({
+    multiple: false,
+    accept: "image/*",
+    resetOnOpen: true,
+    onChange: (files) => {
+      const file = files?.[0];
+      if (!file) return;
+      uploadImage(file, {
+        onSuccess: (data) => editor?.chain().focus().setImage({ src: data.url }).run(),
+        onError: (err) => openAlertModal("上传失败", `${err}`),
+      });
+    },
+  });
+
+  // 编辑模式：回填表单 + 编辑器
+  useEffect(() => {
+    if (!opened) return;
+    if (editing) {
+      form.setValues({
+        title: editing.title,
+        level: editing.level,
+        type: editing.type,
+        expire: editing.expire_time ?? null,
+        audience:
+          editing.audience_type === "permission"
+            ? { type: "permission", permission: editing.audience_permission }
+            : { type: "all" },
+      });
+      editor?.commands.setContent(editing.content || "");
+    } else {
+      form.reset();
+      if (lockedUserIds) {
+        form.setFieldValue("audience", { type: "users", user_ids: lockedUserIds });
+      }
+      editor?.commands.clearContent();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened, editing, editor, lockedUserIds]);
+
+  const submit = (values: FormValues) => {
+    const content = editor?.getHTML() ?? "";
+    if (!content || content === "<p></p>") {
+      openAlertModal("正文不能为空", "请填写通知正文。");
+      return;
+    }
+    if (!editing && values.audience.type === "permission" && !values.audience.permission) {
+      openAlertModal("请选择权限", "指定权限受众需要至少选择一个权限。");
+      return;
+    }
+
+    const payload: PublishNotificationPayload = {
+      title: values.title,
+      content,
+      type: values.type,
+      level: values.level,
+      audience: values.audience,
+      expire_time: values.expire ? dayjs(values.expire).toISOString() : undefined,
+    };
+
+    const onError = (err: unknown) => openRetryModal("提交失败", `${err}`, () => submit(values));
+    if (editing) {
+      update({ id: editing.id, payload }, { onError, onSettled: onClose });
+    } else {
+      publish(payload, { onError, onSettled: onClose });
+    }
+  };
+
+  const SelectedTypeIcon = getNotificationTypeIcon(form.values.type);
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={editing ? "编辑通知" : "发送通知"}
+      size="lg"
+      centered
+    >
+      <form onSubmit={form.onSubmit(submit)}>
+        <TextInput
+          label="标题"
+          placeholder="请输入标题"
+          mb="xs"
+          {...form.getInputProps("title")}
+        />
+        <Input.Wrapper label="级别" mb="xs">
+          <Chip.Group {...form.getInputProps("level")}>
+            <Group gap="xs">
+              <Chip size="xs" value="normal">
+                普通
+              </Chip>
+              <Chip size="xs" value="important" color="yellow">
+                重要
+              </Chip>
+              <Chip size="xs" value="urgent" color="red">
+                紧急
+              </Chip>
+            </Group>
+          </Chip.Group>
+        </Input.Wrapper>
+        <Group grow align="flex-start" mb="xs">
+          <Select
+            label="类型"
+            data={TYPE_OPTIONS}
+            allowDeselect={false}
+            leftSection={<SelectedTypeIcon size={18} />}
+            renderOption={({ option }) => {
+              const OptIcon = getNotificationTypeIcon(option.value);
+              return (
+                <Group gap="xs">
+                  <OptIcon size={18} />
+                  <span>{option.label}</span>
+                </Group>
+              );
+            }}
+            comboboxProps={{
+              transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+            }}
+            {...form.getInputProps("type")}
+          />
+          {match({ editing, lockedUserIds })
+            .with({ editing: P.nullish, lockedUserIds: P.array() }, ({ lockedUserIds }) => (
+              <TextInput
+                label="接收对象"
+                value={`指定用户（${lockedUserIds.length} 人）`}
+                disabled
+              />
+            ))
+            .with({ editing: { audience_type: "users" } }, () => (
+              <TextInput label="接收对象" value="指定用户" disabled />
+            ))
+            .otherwise(() => {
+              const { audience } = form.values;
+              return (
+                <Stack gap="xs">
+                  <Select
+                    label="接收对象"
+                    data={[
+                      { value: "all", label: "全体用户" },
+                      { value: "permission", label: "指定权限" },
+                    ]}
+                    value={audience.type === "permission" ? "permission" : "all"}
+                    allowDeselect={false}
+                    disabled={!!editing}
+                    onChange={(v) =>
+                      form.setFieldValue(
+                        "audience",
+                        v === "permission" ? { type: "permission", permission: 0 } : { type: "all" },
+                      )
+                    }
+                    comboboxProps={{
+                      transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+                    }}
+                  />
+                  {audience.type === "permission" && (
+                    <MultiSelect
+                      label="权限"
+                      placeholder="选择权限"
+                      data={PERMISSION_OPTIONS}
+                      value={permissionToList(audience.permission ?? 0).map(String)}
+                      disabled={!!editing}
+                      onChange={(vals) =>
+                        form.setFieldValue("audience", {
+                          type: "permission",
+                          permission: listToPermission(vals.map(Number)),
+                        })
+                      }
+                      comboboxProps={{
+                        transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+                      }}
+                    />
+                  )}
+                </Stack>
+              );
+            })}
+        </Group>
+        <DatesProvider settings={{ locale: "zh-cn", firstDayOfWeek: 0, weekendDays: [0, 6] }}>
+          <DateTimePicker
+            label="过期时间（可选）"
+            placeholder="到期后不再展示"
+            valueFormat="YYYY-MM-DD HH:mm:ss"
+            clearable
+            mb="xs"
+            {...form.getInputProps("expire")}
+          />
+        </DatesProvider>
+
+        <Text size="sm" mb={3}>
+          正文
+        </Text>
+        <RichTextEditor editor={editor}>
+          <RichTextEditor.Toolbar>
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Bold />
+              <RichTextEditor.Italic />
+              <RichTextEditor.Underline />
+              <RichTextEditor.Strikethrough />
+              <RichTextEditor.ClearFormatting />
+              <RichTextEditor.Highlight />
+              <RichTextEditor.Code />
+            </RichTextEditor.ControlsGroup>
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.H1 />
+              <RichTextEditor.H2 />
+              <RichTextEditor.H3 />
+            </RichTextEditor.ControlsGroup>
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Blockquote />
+              <RichTextEditor.Hr />
+              <RichTextEditor.BulletList />
+              <RichTextEditor.OrderedList />
+            </RichTextEditor.ControlsGroup>
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Link />
+              <RichTextEditor.Unlink />
+              <RichTextEditor.Control onClick={imageDialog.open} aria-label="插入图片">
+                <IconPhoto size={16} color="gray" />
+              </RichTextEditor.Control>
+            </RichTextEditor.ControlsGroup>
+          </RichTextEditor.Toolbar>
+          <ScrollArea style={{ height: 240 }}>
+            <RichTextEditor.Content />
+          </ScrollArea>
+        </RichTextEditor>
+
+        <Group justify="flex-end" mt="md">
+          <Button variant="default" onClick={onClose}>
+            取消
+          </Button>
+          <Button type="submit">{editing ? "保存" : "发布"}</Button>
+        </Group>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/Notifications/PublishNotificationModal.tsx
+++ b/src/components/Notifications/PublishNotificationModal.tsx
@@ -2,17 +2,19 @@ import { useEffect } from "react";
 import { useForm } from "@mantine/form";
 import {
   Button,
+  Checkbox,
   Chip,
   Group,
+  HoverCard,
   Input,
   Modal,
   MultiSelect,
   ScrollArea,
   Select,
   Stack,
-  Switch,
   Text,
   TextInput,
+  ThemeIcon,
 } from "@mantine/core";
 import { DatesProvider, DateTimePicker } from "@mantine/dates";
 import { useFileDialog } from "@mantine/hooks";
@@ -23,7 +25,7 @@ import { Link, RichTextEditor } from "@mantine/tiptap";
 import { Image } from "@tiptap/extension-image";
 import { Highlight } from "@tiptap/extension-highlight";
 import { TextAlign } from "@tiptap/extension-text-align";
-import { IconPhoto } from "@tabler/icons-react";
+import { IconHelp, IconPhoto } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import "dayjs/locale/zh-cn";
 import { useBackDismiss } from "@/hooks/useBackDismiss.ts";
@@ -289,12 +291,24 @@ export function PublishNotificationModal({
             })}
         </Group>
         {!lockedUserIds && editing?.audience_type !== "users" && (
-          <Switch
-            label="常驻通知"
-            description="发布后才注册的新用户也能看到，适合欢迎、规则等 onboarding 公告。"
-            mb="xs"
-            {...form.getInputProps("persistent", { type: "checkbox" })}
-          />
+          <Group gap="xs" align="center" mb="xs">
+            <Checkbox
+              label="常驻通知"
+              {...form.getInputProps("persistent", { type: "checkbox" })}
+            />
+            <HoverCard width={280} shadow="md" withArrow>
+              <HoverCard.Target>
+                <ThemeIcon variant="subtle" color="gray" size="xs" style={{ cursor: "pointer" }}>
+                  <IconHelp />
+                </ThemeIcon>
+              </HoverCard.Target>
+              <HoverCard.Dropdown>
+                <Text size="sm">
+                  勾选后，发布之后才注册的新用户也能看到此通知；不勾选则只有发布时已注册的用户可见。
+                </Text>
+              </HoverCard.Dropdown>
+            </HoverCard>
+          </Group>
         )}
         <DatesProvider settings={{ locale: "zh-cn", firstDayOfWeek: 0, weekendDays: [0, 6] }}>
           <DateTimePicker

--- a/src/components/Notifications/PublishNotificationModal.tsx
+++ b/src/components/Notifications/PublishNotificationModal.tsx
@@ -122,10 +122,13 @@ export function PublishNotificationModal({
         level: editing.level,
         type: editing.type,
         expire: editing.expire_time ?? null,
+        // 受众发布后不可变（后端 PUT 忽略 audience）；这里按原类型回填，避免 users 类型被回填成 all。
         audience:
           editing.audience_type === "permission"
             ? { type: "permission", permission: editing.audience_permission }
-            : { type: "all" },
+            : editing.audience_type === "users"
+              ? { type: "users", user_ids: [] }
+              : { type: "all" },
       });
       editor?.commands.setContent(editing.content || "");
     } else {
@@ -139,11 +142,11 @@ export function PublishNotificationModal({
   }, [opened, editing, editor, lockedUserIds]);
 
   const submit = (values: FormValues) => {
-    const content = editor?.getHTML() ?? "";
-    if (!content || content === "<p></p>") {
+    if (!editor || editor.isEmpty) {
       openAlertModal("正文不能为空", "请填写通知正文。");
       return;
     }
+    const content = editor.getHTML();
     if (!editing && values.audience.type === "permission" && !values.audience.permission) {
       openAlertModal("请选择权限", "指定权限受众需要至少选择一个权限。");
       return;
@@ -158,11 +161,12 @@ export function PublishNotificationModal({
       expire_time: values.expire ? dayjs(values.expire).toISOString() : undefined,
     };
 
+    // 仅成功后关闭 Modal；失败时保留弹窗与已填内容，由 onError 的重试入口处理。
     const onError = (err: unknown) => openRetryModal("提交失败", `${err}`, () => submit(values));
     if (editing) {
-      update({ id: editing.id, payload }, { onError, onSettled: onClose });
+      update({ id: editing.id, payload }, { onError, onSuccess: onClose });
     } else {
-      publish(payload, { onError, onSettled: onClose });
+      publish(payload, { onError, onSuccess: onClose });
     }
   };
 
@@ -177,12 +181,7 @@ export function PublishNotificationModal({
       centered
     >
       <form onSubmit={form.onSubmit(submit)}>
-        <TextInput
-          label="标题"
-          placeholder="请输入标题"
-          mb="xs"
-          {...form.getInputProps("title")}
-        />
+        <TextInput label="标题" placeholder="请输入标题" mb="xs" {...form.getInputProps("title")} />
         <Input.Wrapper label="级别" mb="xs">
           <Chip.Group {...form.getInputProps("level")}>
             <Group gap="xs">
@@ -245,11 +244,17 @@ export function PublishNotificationModal({
                     onChange={(v) =>
                       form.setFieldValue(
                         "audience",
-                        v === "permission" ? { type: "permission", permission: 0 } : { type: "all" },
+                        v === "permission"
+                          ? { type: "permission", permission: 0 }
+                          : { type: "all" },
                       )
                     }
                     comboboxProps={{
-                      transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+                      transitionProps: {
+                        transition: "fade",
+                        duration: 100,
+                        timingFunction: "ease",
+                      },
                     }}
                   />
                   {audience.type === "permission" && (
@@ -266,7 +271,11 @@ export function PublishNotificationModal({
                         })
                       }
                       comboboxProps={{
-                        transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+                        transitionProps: {
+                          transition: "fade",
+                          duration: 100,
+                          timingFunction: "ease",
+                        },
                       }}
                     />
                   )}

--- a/src/components/Notifications/UrgentNotificationModal.tsx
+++ b/src/components/Notifications/UrgentNotificationModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button, Group, Modal } from "@mantine/core";
 import { useBackDismiss } from "@/hooks/useBackDismiss.ts";
-import { useNotifications } from "@/hooks/queries/useNotifications.ts";
+import { useUrgentNotifications } from "@/hooks/queries/useUrgentNotifications.ts";
 import { useMarkNotificationRead } from "@/hooks/mutations/useNotificationMutations.ts";
 import { getNotificationDisplay } from "@/components/Notifications/notificationTemplates.tsx";
 import { NotificationProps } from "@/types/notification";
@@ -19,7 +19,7 @@ function loadSeen(): string[] {
 }
 
 export function UrgentNotificationModal() {
-  const { data } = useNotifications({ filter: "unread", page: 1, pageSize: 20 });
+  const urgent = useUrgentNotifications();
   const { mutate: markRead } = useMarkNotificationRead();
   const [current, setCurrent] = useState<NotificationProps | null>(null);
   const [opened, setOpened] = useState(false);
@@ -27,14 +27,12 @@ export function UrgentNotificationModal() {
   useEffect(() => {
     if (opened) return;
     const seen = loadSeen();
-    const next = (data?.notifications ?? []).find(
-      (n) => n.level === "urgent" && !n.read && !seen.includes(keyOf(n)),
-    );
+    const next = urgent.find((n) => !seen.includes(keyOf(n)));
     if (next) {
       setCurrent(next);
       setOpened(true);
     }
-  }, [data, opened]);
+  }, [urgent, opened]);
 
   const dismiss = (read: boolean) => {
     if (current) {

--- a/src/components/Notifications/UrgentNotificationModal.tsx
+++ b/src/components/Notifications/UrgentNotificationModal.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { Button, Group, Modal } from "@mantine/core";
+import { useBackDismiss } from "@/hooks/useBackDismiss.ts";
+import { useNotifications } from "@/hooks/queries/useNotifications.ts";
+import { useMarkNotificationRead } from "@/hooks/mutations/useNotificationMutations.ts";
+import { getNotificationDisplay } from "@/components/Notifications/notificationTemplates.tsx";
+import { NotificationProps } from "@/types/notification";
+
+const SEEN_KEY = "notification.urgentSeen";
+
+const keyOf = (n: NotificationProps) => `${n.category}-${n.id}`;
+
+function loadSeen(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(SEEN_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function UrgentNotificationModal() {
+  const { data } = useNotifications({ filter: "unread", page: 1, pageSize: 20 });
+  const { mutate: markRead } = useMarkNotificationRead();
+  const [current, setCurrent] = useState<NotificationProps | null>(null);
+  const [opened, setOpened] = useState(false);
+
+  useEffect(() => {
+    if (opened) return;
+    const seen = loadSeen();
+    const next = (data?.notifications ?? []).find(
+      (n) => n.level === "urgent" && !n.read && !seen.includes(keyOf(n)),
+    );
+    if (next) {
+      setCurrent(next);
+      setOpened(true);
+    }
+  }, [data, opened]);
+
+  const dismiss = (read: boolean) => {
+    if (current) {
+      localStorage.setItem(SEEN_KEY, JSON.stringify([...loadSeen(), keyOf(current)]));
+      if (read) markRead({ category: current.category, id: current.id });
+    }
+    setOpened(false);
+  };
+
+  const close = () => dismiss(false);
+  const acknowledge = () => dismiss(true);
+
+  useBackDismiss(opened, close);
+
+  const display = current ? getNotificationDisplay(current) : null;
+
+  return (
+    <Modal opened={opened} onClose={close} title={display?.title} centered>
+      {display && (
+        <>
+          {display.body}
+          <Group justify="flex-end" mt="lg">
+            <Button onClick={acknowledge}>我知道了</Button>
+          </Group>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Notifications/notificationIcons.ts
+++ b/src/components/Notifications/notificationIcons.ts
@@ -3,6 +3,7 @@ import {
   IconCalendarEvent,
   IconCode,
   IconGavel,
+  IconHeart,
   IconRocket,
   IconTool,
 } from "@tabler/icons-react";
@@ -16,6 +17,7 @@ const TYPE_ICONS: Record<string, typeof IconBell> = {
   // 个人通知类型
   developer_approved: IconCode,
   alias_approved: IconGavel,
+  comment_liked: IconHeart,
 };
 
 export function getNotificationTypeIcon(type: string) {

--- a/src/components/Notifications/notificationIcons.ts
+++ b/src/components/Notifications/notificationIcons.ts
@@ -1,0 +1,23 @@
+import {
+  IconBell,
+  IconCalendarEvent,
+  IconCode,
+  IconGavel,
+  IconRocket,
+  IconTool,
+} from "@tabler/icons-react";
+
+const TYPE_ICONS: Record<string, typeof IconBell> = {
+  // 广播类型
+  maintenance: IconTool,
+  version: IconRocket,
+  event: IconCalendarEvent,
+  developer: IconCode,
+  // 个人通知类型
+  developer_approved: IconCode,
+  alias_approved: IconGavel,
+};
+
+export function getNotificationTypeIcon(type: string) {
+  return TYPE_ICONS[type] ?? IconBell;
+}

--- a/src/components/Notifications/notificationTemplates.tsx
+++ b/src/components/Notifications/notificationTemplates.tsx
@@ -1,0 +1,81 @@
+import { ReactNode } from "react";
+import { Typography } from "@mantine/core";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import { Game } from "@/types/game";
+import { NotificationAction, NotificationProps } from "@/types/notification";
+
+export interface NotificationDisplay {
+  title: string;
+  body: ReactNode;
+  action?: NotificationAction;
+}
+
+type TemplateData = Record<string, unknown>;
+type NotificationTemplate = (data: TemplateData) => {
+  title: string;
+  body: ReactNode;
+  action?: NotificationAction;
+};
+
+const templates: Record<string, NotificationTemplate> = {
+  developer_approved: (data) => ({
+    title: "开发者申请已通过",
+    body: (
+      <>
+        <p>你好，{String(data.name ?? "")}：</p>
+        <p>你已成功成为查分器的开发者！欢迎加入。</p>
+        <p>
+          请访问
+          <a href="https://maimai.lxns.net/docs#%E5%BC%80%E5%8F%91%E8%80%85%E6%96%87%E6%A1%A3">
+            开发者文档
+          </a>
+          ，了解如何对接查分器。
+        </p>
+        <p>
+          如有问题或建议可加入开发者交流群参与讨论。如你计划使用游戏内 API 接入，请加入开发者交流群，并联系管理员。
+        </p>
+        <p>
+          开发者交流群请前往
+          <a href="https://maimai.lxns.net/developer">
+            开发者面板
+          </a>
+          加入。
+        </p>
+      </>
+    ),
+  }),
+  alias_approved: (data) => ({
+    title: "曲目别名已被批准",
+    body: <p>你提交的曲目别名「{String(data.alias ?? "")}」已被批准，现在可以在查分器内搜索了。</p>,
+    action:
+      data.song_id != null
+        ? { type: "song", game: data.game as Game, song_id: Number(data.song_id) }
+        : undefined,
+  }),
+};
+
+function renderContent(content: string): ReactNode {
+  return (
+    <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+      {content}
+    </Markdown>
+  );
+}
+
+export function getNotificationDisplay(n: NotificationProps): NotificationDisplay {
+  const body = (content: ReactNode) => <Typography>{content}</Typography>;
+
+  if (n.category === "broadcast") {
+    return { title: n.title, body: body(renderContent(n.content)), action: n.action };
+  }
+
+  const template = templates[n.type];
+  if (template) {
+    const r = template(n.data ?? {});
+    return { title: r.title, body: body(r.body), action: r.action ?? n.action };
+  }
+
+  return { title: "新通知", body: body(<p>你有一条新通知。</p>), action: n.action };
+}

--- a/src/components/Notifications/notificationTemplates.tsx
+++ b/src/components/Notifications/notificationTemplates.tsx
@@ -34,13 +34,12 @@ const templates: Record<string, NotificationTemplate> = {
           ，了解如何对接查分器。
         </p>
         <p>
-          如有问题或建议可加入开发者交流群参与讨论。如你计划使用游戏内 API 接入，请加入开发者交流群，并联系管理员。
+          如有问题或建议可加入开发者交流群参与讨论。如你计划使用游戏内 API
+          接入，请加入开发者交流群，并联系管理员。
         </p>
         <p>
           开发者交流群请前往
-          <a href="https://maimai.lxns.net/developer">
-            开发者面板
-          </a>
+          <a href="https://maimai.lxns.net/developer">开发者面板</a>
           加入。
         </p>
       </>

--- a/src/components/Notifications/notificationTemplates.tsx
+++ b/src/components/Notifications/notificationTemplates.tsx
@@ -53,6 +53,26 @@ const templates: Record<string, NotificationTemplate> = {
         ? { type: "song", game: data.game as Game, song_id: Number(data.song_id) }
         : undefined,
   }),
+  comment_liked: (data) => ({
+    title: "你的评论被点赞了",
+    body: (
+      <p>
+        <strong>{String(data.liker ?? "")}</strong> 点赞了你的评论。
+      </p>
+    ),
+    action:
+      data.song_id != null && data.difficulty != null
+        ? {
+            type: "score",
+            game: data.game as Game,
+            song_id: Number(data.song_id),
+            song_type: data.song_type as string | undefined,
+            difficulty: Number(data.difficulty),
+          }
+        : data.song_id != null
+          ? { type: "song", game: data.game as Game, song_id: Number(data.song_id) }
+          : undefined,
+  }),
 };
 
 function renderContent(content: string): ReactNode {

--- a/src/components/Scores/AdvancedFilter.tsx
+++ b/src/components/Scores/AdvancedFilter.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  Chip,
-  Flex,
   Grid,
   Group,
   Image,
@@ -14,9 +12,9 @@ import {
   Text,
 } from "@mantine/core";
 import { IconReload } from "@tabler/icons-react";
+import { FilterChips } from "@/components/FilterChips.tsx";
 import { MaimaiSongList } from "@/utils/api/song/maimai.ts";
 import { ChunithmSongList } from "@/utils/api/song/chunithm.ts";
-import React from "react";
 import { DatePickerInput, DatesProvider } from "@mantine/dates";
 import "dayjs/locale/zh-cn";
 import useSongListStore from "@/hooks/useSongListStore.ts";
@@ -152,35 +150,6 @@ function findRatingPreset(presets: RatingPreset[], value: [number, number]) {
     null
   );
 }
-
-const FilterChips = ({
-  title,
-  value,
-  onChange,
-  options,
-}: {
-  title: string;
-  value: string[];
-  onChange: (value: string[]) => void;
-  options: { value: string; label: React.ReactNode }[];
-}) => {
-  return (
-    <div>
-      <Text fz="xs" c="dimmed" mb={3}>
-        {title}
-      </Text>
-      <Flex rowGap="xs" columnGap="md" wrap="wrap">
-        <Chip.Group multiple value={value} onChange={onChange}>
-          {options.map((opt) => (
-            <Chip key={opt.value} variant="filled" size="xs" value={opt.value}>
-              {opt.label}
-            </Chip>
-          ))}
-        </Chip.Group>
-      </Flex>
-    </div>
-  );
-};
 
 interface AdvancedFilterProps {
   filters: ScoreFilters;

--- a/src/components/Scores/ScoreModal.tsx
+++ b/src/components/Scores/ScoreModal.tsx
@@ -89,7 +89,6 @@ type DifficultyState =
 
 export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) => {
   useBackDismiss(opened, () => onClose());
-  const [songList, setSongList] = useState<MaimaiSongList | ChunithmSongList>();
   const [songState, setSongState] = useState<SongState | null>(null);
   const [difficultyState, setDifficultyState] = useState<DifficultyState | null>(null);
   const combobox = useCombobox({
@@ -97,6 +96,7 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
   });
 
   const getSongList = useSongListStore((state) => state.getSongList);
+  const songList = getSongList(game);
   const small = useMediaQuery("(max-width: 30rem)");
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -113,7 +113,6 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
 
   useEffect(() => {
     setSongState(null);
-    setSongList(getSongList(game));
   }, [game]);
 
   useEffect(() => {

--- a/src/components/Shell/Navbar/Navbar.tsx
+++ b/src/components/Shell/Navbar/Navbar.tsx
@@ -5,6 +5,7 @@ import { checkPermission, UserPermission } from "@/utils/session.ts";
 import { useLogoutUser } from "@/hooks/mutations/useUserMutations.ts";
 import {
   IconAward,
+  IconBell,
   IconChartBar,
   IconCloudUpload,
   IconCode,
@@ -20,6 +21,7 @@ import {
   IconUserCircle,
 } from "@tabler/icons-react";
 import classes from "./Navbar.module.css";
+import { useUnreadCount } from "@/hooks/queries/useUnreadCount.ts";
 
 interface NavbarProps {
   style?: React.CSSProperties;
@@ -30,11 +32,18 @@ export default function Navbar({ style, onClose }: NavbarProps) {
   const [active, setActive] = useState("");
   const isLoggedOut = typeof window !== "undefined" ? !localStorage.getItem("token") : true;
   const { mutate: mutateLogout } = useLogoutUser();
+  const unreadCount = useUnreadCount();
 
   const navbarData = useMemo(
     () => [
       { label: "首页", icon: <IconHome stroke={1.5} />, to: "/", enabled: true },
       { label: "同步游戏数据", icon: <IconCloudUpload stroke={1.5} />, to: "/sync", enabled: true },
+      {
+        label: "通知",
+        icon: <IconBell stroke={1.5} />,
+        to: "/notifications",
+        enabled: !isLoggedOut,
+      },
       {
         label: "账号详情",
         icon: <IconUserCircle stroke={1.5} />,
@@ -128,7 +137,12 @@ export default function Navbar({ style, onClose }: NavbarProps) {
               item.enabled && (
                 <Container key={item.label}>
                   {item.divider && <Divider className={classes.divider} mt={10} mb={10} />}
-                  <NavbarButton {...item} active={active} onClose={onClose} />
+                  <NavbarButton
+                    {...item}
+                    count={item.label === "通知" ? unreadCount : undefined}
+                    active={active}
+                    onClose={onClose}
+                  />
                 </Container>
               ),
           )}

--- a/src/components/Shell/Navbar/NavbarButton.tsx
+++ b/src/components/Shell/Navbar/NavbarButton.tsx
@@ -1,4 +1,4 @@
-import { Badge, Group, Text } from "@mantine/core";
+import { Badge, Group, Indicator, Text } from "@mantine/core";
 import React from "react";
 import classes from "./Navbar.module.css";
 import { navigate } from "vike/client/router";
@@ -7,6 +7,7 @@ interface NavbarButtonProps {
   label: string;
   icon: React.ReactNode;
   is_new?: boolean;
+  count?: number;
   to?: string;
   active?: string;
   onClose(): void;
@@ -17,6 +18,7 @@ export const NavbarButton = ({
   label,
   icon,
   is_new,
+  count,
   to,
   active,
   onClose,
@@ -36,7 +38,14 @@ export const NavbarButton = ({
       }}
     >
       <Group>
-        <div className={classes.navbarLinkIcon}>{icon}</div>
+        <Indicator
+          color="red"
+          size={16}
+          disabled={!count}
+          label={(count ?? 0) > 99 ? "99+" : count}
+        >
+          <div className={classes.navbarLinkIcon}>{icon}</div>
+        </Indicator>
         <Text size="sm">{label}</Text>
         {is_new && (
           <Badge

--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -7,6 +7,7 @@ import { useScroll, useWindowSize } from "react-use";
 import { CreateScoreModalProvider } from "../ModalProvider/CreateScoreModalProvider.tsx";
 import { ScoreModalProvider } from "../ModalProvider/ScoreModalProvider.tsx";
 import { CreateAliasModalProvider } from "../ModalProvider/CreateAliasModalProvider.tsx";
+import { UrgentNotificationModal } from "@/components/Notifications/UrgentNotificationModal.tsx";
 
 export const NAVBAR_BREAKPOINT = 992;
 
@@ -113,6 +114,7 @@ export default function Shell({ navbarOpened, onNavbarToggle, viewportRef, child
       <ScoreModalProvider />
       <CreateScoreModalProvider />
       <CreateAliasModalProvider />
+      <UrgentNotificationModal />
     </div>
   );
 }

--- a/src/hooks/mutations/useAdminNotificationMutations.ts
+++ b/src/hooks/mutations/useAdminNotificationMutations.ts
@@ -1,0 +1,54 @@
+import { useMutation, UseMutationOptions, useQueryClient } from "@tanstack/react-query";
+import { apiMutationFn } from "../queries/mutationFn.ts";
+import {
+  publishNotification,
+  updateNotification,
+  deleteNotification,
+  uploadNotificationImage,
+} from "@/utils/api/notification.ts";
+import { NotificationImageUploadResponse, PublishNotificationPayload } from "@/types/notification";
+import { queryKeys } from "../queries/queryKeys.ts";
+
+const invalidate = (qc: ReturnType<typeof useQueryClient>) => {
+  qc.invalidateQueries({ queryKey: queryKeys.notifications.admin.list() });
+  qc.invalidateQueries({
+    predicate: (q) =>
+      typeof q.queryKey[0] === "string" && q.queryKey[0].startsWith("user/notifications"),
+  });
+};
+
+export const usePublishNotification = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: PublishNotificationPayload) =>
+      apiMutationFn(() => publishNotification(payload)),
+    onSuccess: () => invalidate(qc),
+  });
+};
+
+export const useUpdateNotification = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: PublishNotificationPayload }) =>
+      apiMutationFn(() => updateNotification(id, payload)),
+    onSuccess: () => invalidate(qc),
+  });
+};
+
+export const useDeleteNotification = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiMutationFn(() => deleteNotification(id)),
+    onSuccess: () => invalidate(qc),
+  });
+};
+
+export const useUploadNotificationImage = (
+  options?: UseMutationOptions<NotificationImageUploadResponse, Error, File>,
+) => {
+  return useMutation({
+    mutationFn: (file: File) =>
+      apiMutationFn<NotificationImageUploadResponse>(() => uploadNotificationImage(file)),
+    ...options,
+  });
+};

--- a/src/hooks/mutations/useNotificationMutations.ts
+++ b/src/hooks/mutations/useNotificationMutations.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiMutationFn } from "../queries/mutationFn.ts";
+import { markNotificationRead, markAllNotificationsRead } from "@/utils/api/notification.ts";
+
+const invalidateNotifications = (qc: ReturnType<typeof useQueryClient>) =>
+  qc.invalidateQueries({
+    predicate: (q) =>
+      typeof q.queryKey[0] === "string" && q.queryKey[0].startsWith("user/notifications"),
+  });
+
+export const useMarkNotificationRead = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ category, id }: { category: string; id: number }) =>
+      apiMutationFn(() => markNotificationRead(category, id)),
+    onSuccess: () => invalidateNotifications(qc),
+  });
+};
+
+export const useMarkAllNotificationsRead = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiMutationFn(() => markAllNotificationsRead()),
+    onSuccess: () => invalidateNotifications(qc),
+  });
+};

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -68,6 +68,7 @@ export const queryKeys = {
   notifications: {
     list: (params: URLSearchParams) => [`user/notifications?${params.toString()}`] as const,
     unreadCount: () => ["user/notifications/unread-count"] as const,
+    urgent: () => ["user/notifications/urgent"] as const,
     admin: {
       list: () => ["user/admin/notifications"] as const,
     },

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -65,4 +65,11 @@ export const queryKeys = {
     list: (game: Game, params: URLSearchParams) =>
       [`user/${game}/comment/list?${params.toString()}`] as const,
   },
+  notifications: {
+    list: (params: URLSearchParams) => [`user/notifications?${params.toString()}`] as const,
+    unreadCount: () => ["user/notifications/unread-count"] as const,
+    admin: {
+      list: () => ["user/admin/notifications"] as const,
+    },
+  },
 } as const;

--- a/src/hooks/queries/useAdminNotifications.ts
+++ b/src/hooks/queries/useAdminNotifications.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { AdminBroadcast } from "@/types/notification";
+import { queryKeys } from "./queryKeys.ts";
+
+export const useAdminNotifications = () => {
+  const { data, error, isLoading } = useQuery<AdminBroadcast[]>({
+    queryKey: queryKeys.notifications.admin.list(),
+    staleTime: 30 * 1000,
+  });
+
+  return { broadcasts: data ?? [], isLoading, error };
+};

--- a/src/hooks/queries/useNotifications.ts
+++ b/src/hooks/queries/useNotifications.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { NotificationListResponse } from "@/types/notification";
+import { queryKeys } from "./queryKeys.ts";
+
+interface Options {
+  filter: "all" | "unread";
+  page: number;
+  pageSize?: number;
+}
+
+export const useNotifications = ({ filter, page, pageSize = 20 }: Options) => {
+  const isLoggedOut = typeof window === "undefined" || !localStorage.getItem("token");
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+    filter,
+  });
+
+  const { data, error, isLoading } = useQuery<NotificationListResponse>({
+    queryKey: queryKeys.notifications.list(params),
+    enabled: !isLoggedOut,
+    staleTime: 30 * 1000,
+  });
+
+  return { data, isLoading, error };
+};

--- a/src/hooks/queries/useUnreadCount.ts
+++ b/src/hooks/queries/useUnreadCount.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "./queryKeys.ts";
+
+export const useUnreadCount = (): number => {
+  const isLoggedOut = typeof window === "undefined" || !localStorage.getItem("token");
+
+  const { data } = useQuery<{ unread_count: number }>({
+    queryKey: queryKeys.notifications.unreadCount(),
+    enabled: !isLoggedOut,
+    refetchOnWindowFocus: true,
+    staleTime: 60 * 1000,
+  });
+
+  return data?.unread_count ?? 0;
+};

--- a/src/hooks/queries/useUrgentNotifications.ts
+++ b/src/hooks/queries/useUrgentNotifications.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { NotificationProps } from "@/types/notification";
+import { queryKeys } from "./queryKeys.ts";
+
+// 进站强提示 Modal 专用：后端已过滤「可见 + 未读 + level=urgent」并按时间倒序，不分页。
+export const useUrgentNotifications = (): NotificationProps[] => {
+  const isLoggedOut = typeof window === "undefined" || !localStorage.getItem("token");
+
+  const { data } = useQuery<{ notifications: NotificationProps[] }>({
+    queryKey: queryKeys.notifications.urgent(),
+    enabled: !isLoggedOut,
+    staleTime: 60 * 1000,
+  });
+
+  return data?.notifications ?? [];
+};

--- a/src/hooks/useNotificationAction.ts
+++ b/src/hooks/useNotificationAction.ts
@@ -1,0 +1,25 @@
+import { navigate } from "vike/client/router";
+import useGame from "@/hooks/useGame.ts";
+import { NotificationAction } from "@/types/notification";
+
+export function useNotificationAction() {
+  const [, setGame] = useGame();
+
+  return (action?: NotificationAction): void => {
+    if (!action) return;
+
+    if (action.type === "link") {
+      if (action.url.startsWith("http")) {
+        window.open(action.url, "_blank", "noopener");
+      } else {
+        navigate(action.url);
+      }
+      return;
+    }
+
+    if (action.type === "song") {
+      setGame(action.game);
+      navigate(`/songs?game=${action.game}&song_id=${action.song_id}`);
+    }
+  };
+}

--- a/src/hooks/useNotificationAction.ts
+++ b/src/hooks/useNotificationAction.ts
@@ -1,11 +1,16 @@
 import { navigate } from "vike/client/router";
 import useGame from "@/hooks/useGame.ts";
+import useScoreStore from "@/hooks/useScoreStore.ts";
+import { fetchAPI } from "@/utils/api/api.ts";
+import { openAlertModal } from "@/utils/modal.tsx";
+import { ChunithmScoreProps, MaimaiScoreProps } from "@/types/score";
 import { NotificationAction } from "@/types/notification";
 
 export function useNotificationAction() {
   const [, setGame] = useGame();
+  const openScoreModal = useScoreStore((state) => state.openModal);
 
-  return (action?: NotificationAction): void => {
+  return async (action?: NotificationAction): Promise<void> => {
     if (!action) return;
 
     if (action.type === "link") {
@@ -20,6 +25,36 @@ export function useNotificationAction() {
     if (action.type === "song") {
       setGame(action.game);
       navigate(`/songs?game=${action.game}&song_id=${action.song_id}`);
+      return;
+    }
+
+    if (action.type === "score") {
+      setGame(action.game);
+      const params = new URLSearchParams({ song_id: String(action.song_id) });
+      if (action.song_type) params.append("song_type", action.song_type);
+
+      try {
+        const res = await fetchAPI(`user/${action.game}/player/bests?${params.toString()}`, {
+          method: "GET",
+        });
+        const data = await res.json();
+        if (!data.success) throw new Error(data.message);
+
+        const scores = (data.data ?? []) as (MaimaiScoreProps | ChunithmScoreProps)[];
+        const score = scores.find(
+          (s) =>
+            s.level_index === action.difficulty &&
+            (!action.song_type || !("type" in s) || s.type === action.song_type),
+        );
+
+        if (!score) {
+          openAlertModal("成绩不存在", "目标成绩可能已被删除或尚未上传。");
+          return;
+        }
+        openScoreModal({ game: action.game, score });
+      } catch (e) {
+        openAlertModal("打开成绩失败", `${e}`);
+      }
     }
   };
 }

--- a/src/pages/(csr)/notifications/+Page.tsx
+++ b/src/pages/(csr)/notifications/+Page.tsx
@@ -1,0 +1,10 @@
+import { RouteGuard } from "@/components/RouteGuard";
+import Notifications from "@/pages/notifications/Notifications";
+
+export default function Page() {
+  return (
+    <RouteGuard>
+      <Notifications />
+    </RouteGuard>
+  );
+}

--- a/src/pages/(csr)/notifications/+title.ts
+++ b/src/pages/(csr)/notifications/+title.ts
@@ -1,0 +1,1 @@
+export const title = "通知 | maimai DX 查分器";

--- a/src/pages/admin/Panel/Panel.tsx
+++ b/src/pages/admin/Panel/Panel.tsx
@@ -1,6 +1,7 @@
 import { Page } from "@/components/Page/Page.tsx";
 import { AdminUsersSection } from "@/pages/admin/Panel/users/AdminUsersSection.tsx";
 import { AdminDevelopersSection } from "@/pages/admin/Panel/developers/AdminDevelopersSection.tsx";
+import { AdminNotificationsSection } from "@/pages/admin/Panel/notifications/AdminNotificationsSection.tsx";
 
 export function Panel() {
   return (
@@ -12,6 +13,7 @@ export function Panel() {
       tabs={[
         { id: "users", name: "用户列表", children: <AdminUsersSection /> },
         { id: "developers", name: "开发者列表", children: <AdminDevelopersSection /> },
+        { id: "notifications", name: "通知管理", children: <AdminNotificationsSection /> },
       ]}
     />
   );

--- a/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
+++ b/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
@@ -133,11 +133,7 @@ export function AdminNotificationsSection() {
                   </ActionIcon>
                 </Tooltip>
                 <Tooltip label="删除" position="top" withArrow>
-                  <ActionIcon
-                    variant="subtle"
-                    color="red"
-                    onClick={() => handleDelete(b)}
-                  >
+                  <ActionIcon variant="subtle" color="red" onClick={() => handleDelete(b)}>
                     <IconTrash size={18} />
                   </ActionIcon>
                 </Tooltip>
@@ -149,7 +145,12 @@ export function AdminNotificationsSection() {
 
       {totalPages > 1 && (
         <Group justify="center">
-          <Pagination total={totalPages} value={page} onChange={setPage} size={small ? "sm" : "md"} />
+          <Pagination
+            total={totalPages}
+            value={page}
+            onChange={setPage}
+            size={small ? "sm" : "md"}
+          />
         </Group>
       )}
     </Stack>

--- a/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
+++ b/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import {
+  Accordion,
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Pagination,
+  Stack,
+  Text,
+  Tooltip,
+  Typography,
+} from "@mantine/core";
+import { useDisclosure, useMediaQuery } from "@mantine/hooks";
+import { IconEdit, IconPlus, IconTrash } from "@tabler/icons-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import dayjs from "dayjs";
+import { useAdminNotifications } from "@/hooks/queries/useAdminNotifications.ts";
+import { useDeleteNotification } from "@/hooks/mutations/useAdminNotificationMutations.ts";
+import { PublishNotificationModal } from "@/components/Notifications/PublishNotificationModal.tsx";
+import { NotificationTypeIcon } from "@/components/Notifications/NotificationTypeIcon.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { AdminBroadcast } from "@/types/notification";
+
+const PAGE_SIZE = 10;
+
+const audienceLabel: Record<string, string> = {
+  all: "全体",
+  permission: "指定角色",
+  users: "指定用户",
+};
+
+const isExpired = (b: AdminBroadcast) => !!b.expire_time && new Date(b.expire_time) < new Date();
+
+export function AdminNotificationsSection() {
+  const { broadcasts, isLoading } = useAdminNotifications();
+  const { mutate: remove } = useDeleteNotification();
+  const [opened, { open, close }] = useDisclosure(false);
+  const [editing, setEditing] = useState<AdminBroadcast | undefined>(undefined);
+  const [page, setPage] = useState(1);
+  const small = useMediaQuery("(max-width: 30rem)");
+
+  const totalPages = Math.ceil(broadcasts.length / PAGE_SIZE);
+  const pageItems = broadcasts.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const handleDelete = (b: AdminBroadcast) =>
+    openConfirmModal(
+      "删除通知",
+      "确定要删除这条通知吗？将永久删除，不可恢复。",
+      () =>
+        remove(b.id, {
+          onError: (err) => openRetryModal("删除失败", `${err}`, () => handleDelete(b)),
+        }),
+      { confirmProps: { color: "red" } },
+    );
+
+  return (
+    <Stack>
+      <PublishNotificationModal
+        opened={opened}
+        onClose={() => {
+          close();
+          setEditing(undefined);
+        }}
+        editing={editing}
+      />
+
+      <Group justify="flex-end">
+        <Button
+          leftSection={<IconPlus size={16} />}
+          onClick={() => {
+            setEditing(undefined);
+            open();
+          }}
+        >
+          发送通知
+        </Button>
+      </Group>
+
+      {isLoading && (
+        <Group justify="center">
+          <Loader />
+        </Group>
+      )}
+
+      {!isLoading && broadcasts.length === 0 && (
+        <Text c="dimmed" ta="center" py="xl">
+          暂无通知
+        </Text>
+      )}
+
+      <Accordion variant="contained">
+        {pageItems.map((b) => (
+          <Accordion.Item key={b.id} value={String(b.id)}>
+            <Accordion.Control icon={<NotificationTypeIcon type={b.type} level={b.level} />}>
+              <Group gap="xs">
+                <Text
+                  fw={600}
+                  c={isExpired(b) ? "dimmed" : undefined}
+                  td={isExpired(b) ? "line-through" : undefined}
+                >
+                  {b.title}
+                </Text>
+                <Badge variant="light" color="gray">
+                  {audienceLabel[b.audience_type]}
+                </Badge>
+              </Group>
+              <Text c="dimmed" size="xs" mt={4}>
+                发布于 {dayjs(b.create_time).format("YYYY-MM-DD HH:mm")}
+                {b.expire_time && ` · 过期于 ${dayjs(b.expire_time).format("YYYY-MM-DD HH:mm")}`}
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Typography>
+                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+                  {b.content}
+                </Markdown>
+              </Typography>
+              <Group justify="flex-end" mt="sm" gap="xs">
+                <Tooltip label="编辑" position="top" withArrow>
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    onClick={() => {
+                      setEditing(b);
+                      open();
+                    }}
+                  >
+                    <IconEdit size={18} />
+                  </ActionIcon>
+                </Tooltip>
+                <Tooltip label="删除" position="top" withArrow>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    onClick={() => handleDelete(b)}
+                  >
+                    <IconTrash size={18} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            </Accordion.Panel>
+          </Accordion.Item>
+        ))}
+      </Accordion>
+
+      {totalPages > 1 && (
+        <Group justify="center">
+          <Pagination total={totalPages} value={page} onChange={setPage} size={small ? "sm" : "md"} />
+        </Group>
+      )}
+    </Stack>
+  );
+}

--- a/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
+++ b/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
@@ -107,6 +107,11 @@ export function AdminNotificationsSection() {
                 <Badge variant="light" color="gray">
                   {audienceLabel[b.audience_type]}
                 </Badge>
+                {b.persistent && (
+                  <Badge variant="light" color="blue">
+                    常驻
+                  </Badge>
+                )}
               </Group>
               <Text c="dimmed" size="xs" mt={4}>
                 发布于 {dayjs(b.create_time).format("YYYY-MM-DD HH:mm")}

--- a/src/pages/admin/Panel/users/AdminUsersSection.tsx
+++ b/src/pages/admin/Panel/users/AdminUsersSection.tsx
@@ -1,15 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  Group,
-  TextInput,
-  Button,
-  Text,
-  keys,
-  Flex,
-  Card,
-  Badge,
-  Popover,
-} from "@mantine/core";
+import { Group, TextInput, Button, Text, keys, Flex, Card, Badge, Popover } from "@mantine/core";
 import { deleteUsers, getUsers } from "@/utils/api/user.ts";
 import { useDisclosure, useViewportSize } from "@mantine/hooks";
 import { DataTable, DataTableSortStatus } from "mantine-datatable";

--- a/src/pages/admin/Panel/users/AdminUsersSection.tsx
+++ b/src/pages/admin/Panel/users/AdminUsersSection.tsx
@@ -1,21 +1,53 @@
 import { useEffect, useState } from "react";
-import { Group, TextInput, Button, Text, keys, Flex, Card, Badge } from "@mantine/core";
+import {
+  Group,
+  TextInput,
+  Button,
+  Text,
+  keys,
+  Flex,
+  Card,
+  Badge,
+  Popover,
+} from "@mantine/core";
 import { deleteUsers, getUsers } from "@/utils/api/user.ts";
 import { useDisclosure, useViewportSize } from "@mantine/hooks";
 import { DataTable, DataTableSortStatus } from "mantine-datatable";
-import { IconDatabaseOff, IconSearch, IconSend, IconTrash } from "@tabler/icons-react";
+import {
+  IconBell,
+  IconDatabaseOff,
+  IconFilter,
+  IconSearch,
+  IconSend,
+  IconTrash,
+} from "@tabler/icons-react";
 import classes from "@/pages/Page.module.css";
 import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
 import { EditUserModal } from "@/components/Users/EditUserModal.tsx";
 import { SendBatchEmailModal } from "@/components/Users/SendBatchEmailModal.tsx";
-import { permissionToList, UserPermission } from "@/utils/session.ts";
+import { PublishNotificationModal } from "@/components/Notifications/PublishNotificationModal.tsx";
+import { FilterChips } from "@/components/FilterChips.tsx";
+import { listToPermission, permissionToList, UserPermission } from "@/utils/session.ts";
 import { UserProps } from "@/types/user";
+
+const PERMISSION_OPTIONS = [
+  { label: "普通用户", value: UserPermission.User.toString() },
+  { label: "开发者", value: UserPermission.Developer.toString() },
+  { label: "管理员", value: UserPermission.Administrator.toString() },
+];
 
 function filterData(data: UserProps[], search: string) {
   const query = search.toLowerCase().trim();
   return data.filter((item) =>
     keys(item).some((key) => String(item[key]).toLowerCase().includes(query)),
   );
+}
+
+// 按权限筛选：选中任一权限位即匹配（空选择 = 不筛选）。
+function filterByPermission(data: UserProps[], permissions: string[]) {
+  if (permissions.length === 0) return data;
+  const mask = listToPermission(permissions.map(Number));
+  return data.filter((item) => (item.permission & mask) !== 0);
 }
 
 function sortData(
@@ -51,6 +83,8 @@ const AdminUsersContent = () => {
   const [fetching, setFetching] = useState<boolean>(true);
 
   const [search, setSearch] = useState("");
+  const [permissionFilter, setPermissionFilter] = useState<string[]>([]);
+  const [filterOpened, setFilterOpened] = useState(false);
 
   const [editUserModalOpened, editUserModal] = useDisclosure(false);
   const [activeUser, setActiveUser] = useState<UserProps | null>(null);
@@ -67,6 +101,7 @@ const AdminUsersContent = () => {
   });
 
   const [sendBatchEmailModalOpened, sendBatchEmailModal] = useDisclosure(false);
+  const [publishModalOpened, publishModal] = useDisclosure(false);
   const [selectedUsers, setSelectedUsers] = useState<UserProps[]>([]);
 
   useEffect(() => {
@@ -87,13 +122,13 @@ const AdminUsersContent = () => {
 
   useEffect(() => {
     setSortedUsers(
-      sortData(users, {
+      sortData(filterByPermission(users, permissionFilter), {
         sortBy: sortStatus.columnAccessor as keyof UserProps,
         reversed: sortStatus.direction === "desc",
         search,
       }),
     );
-  }, [users, search, sortStatus]);
+  }, [users, search, sortStatus, permissionFilter]);
 
   const getUserHandler = async () => {
     try {
@@ -169,14 +204,63 @@ const AdminUsersContent = () => {
           sendBatchEmailModal.close();
         }}
       />
-      <TextInput
-        placeholder="搜索用户"
-        radius="md"
-        mb="md"
-        leftSection={<IconSearch size={18} />}
-        value={search}
-        onChange={(event) => setSearch(event.currentTarget.value)}
+      <PublishNotificationModal
+        opened={publishModalOpened}
+        onClose={() => publishModal.close()}
+        lockedUserIds={selectedUsers.map((user) => user.id)}
       />
+      <Group mb="md" gap="xs" wrap="nowrap" align="flex-end">
+        <TextInput
+          style={{ flex: 1 }}
+          placeholder="搜索用户"
+          radius="md"
+          leftSection={<IconSearch size={18} />}
+          value={search}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+        />
+        <Popover
+          opened={filterOpened}
+          onChange={setFilterOpened}
+          position="bottom-end"
+          withArrow
+          shadow="md"
+          width={240}
+        >
+          <Popover.Target>
+            <Button
+              variant="default"
+              leftSection={<IconFilter size={18} />}
+              rightSection={
+                permissionFilter.length > 0 ? (
+                  <Badge size="sm" circle>
+                    {permissionFilter.length}
+                  </Badge>
+                ) : null
+              }
+              onClick={() => setFilterOpened((o) => !o)}
+            >
+              筛选
+            </Button>
+          </Popover.Target>
+          <Popover.Dropdown>
+            <FilterChips
+              title="权限"
+              value={permissionFilter}
+              onChange={setPermissionFilter}
+              options={PERMISSION_OPTIONS}
+            />
+            <Button
+              variant="subtle"
+              size="xs"
+              mt="md"
+              disabled={permissionFilter.length === 0}
+              onClick={() => setPermissionFilter([])}
+            >
+              重置
+            </Button>
+          </Popover.Dropdown>
+        </Popover>
+      </Group>
       <Card
         className={classes.card}
         withBorder
@@ -190,7 +274,17 @@ const AdminUsersContent = () => {
           </Text>
           <Group>
             <Button
-              variant="filled"
+              variant="default"
+              leftSection={<IconBell size={20} />}
+              disabled={selectedUsers.length === 0}
+              onClick={() => {
+                publishModal.open();
+              }}
+            >
+              发送通知
+            </Button>
+            <Button
+              variant="default"
               leftSection={<IconSend size={20} />}
               disabled={selectedUsers.length === 0}
               onClick={() => {

--- a/src/pages/notifications/Notifications.tsx
+++ b/src/pages/notifications/Notifications.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  Accordion,
+  Button,
+  Group,
+  Loader,
+  Pagination,
+  SegmentedControl,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import { IconChecks } from "@tabler/icons-react";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/zh-cn";
+import { Page } from "@/components/Page/Page.tsx";
+import { NotificationTypeIcon } from "@/components/Notifications/NotificationTypeIcon.tsx";
+import { getNotificationDisplay } from "@/components/Notifications/notificationTemplates.tsx";
+import { useNotifications } from "@/hooks/queries/useNotifications.ts";
+import {
+  useMarkNotificationRead,
+  useMarkAllNotificationsRead,
+} from "@/hooks/mutations/useNotificationMutations.ts";
+import { useNotificationAction } from "@/hooks/useNotificationAction.ts";
+
+dayjs.extend(relativeTime);
+
+const PAGE_SIZE = 20;
+
+function NotificationFeed() {
+  const [filter, setFilter] = useState<"all" | "unread">("all");
+  const [page, setPage] = useState(1);
+  const [openedItems, setOpenedItems] = useState<string[]>([]);
+  const small = useMediaQuery("(max-width: 30rem)");
+  const { data, isLoading } = useNotifications({ filter, page, pageSize: PAGE_SIZE });
+  const { mutate: markRead } = useMarkNotificationRead();
+  const { mutate: markAll } = useMarkAllNotificationsRead();
+  const dispatch = useNotificationAction();
+
+  const totalPages = Math.ceil((data?.total ?? 0) / PAGE_SIZE);
+
+  const handleFilterChange = (value: string) => {
+    setFilter(value as "all" | "unread");
+    setPage(1);
+    setOpenedItems([]);
+  };
+
+  const handlePageChange = (value: number) => {
+    setPage(value);
+    setOpenedItems([]);
+  };
+
+  const handleOpenChange = (values: string[]) => {
+    values
+      .filter((v) => !openedItems.includes(v))
+      .forEach((key) => {
+        const n = data?.notifications.find((x) => `${x.category}-${x.id}` === key);
+        if (n && !n.read) markRead({ category: n.category, id: n.id });
+      });
+    setOpenedItems(values);
+  };
+
+  return (
+    <Stack>
+      <Group justify="space-between">
+        <SegmentedControl
+          value={filter}
+          onChange={handleFilterChange}
+          data={[
+            { label: "全部", value: "all" },
+            { label: "未读", value: "unread" },
+          ]}
+        />
+        <Button
+          variant="subtle"
+          size="xs"
+          leftSection={<IconChecks size={16} />}
+          onClick={() => markAll()}
+        >
+          全部标为已读
+        </Button>
+      </Group>
+
+      {isLoading && (
+        <Group justify="center">
+          <Loader />
+        </Group>
+      )}
+
+      {!isLoading && (data?.notifications.length ?? 0) === 0 && (
+        <Text c="dimmed" ta="center" py="xl">
+          暂无通知
+        </Text>
+      )}
+
+      <Accordion variant="contained" multiple value={openedItems} onChange={handleOpenChange}>
+        {data?.notifications.map((n) => {
+          const key = `${n.category}-${n.id}`;
+          const display = getNotificationDisplay(n);
+          const action = display.action;
+          return (
+            <Accordion.Item key={key} value={key}>
+              <Accordion.Control
+                icon={<NotificationTypeIcon type={n.type} level={n.level} unread={!n.read} />}
+              >
+                <Group gap="xs" wrap="nowrap" justify="space-between">
+                  <Text fw={n.read ? 500 : 700} size="sm">
+                    {display.title}
+                  </Text>
+                  <Text c="dimmed" size="xs" mr="xs" style={{ whiteSpace: "nowrap" }}>
+                    {dayjs(n.create_time).locale("zh-cn").fromNow()}
+                  </Text>
+                </Group>
+              </Accordion.Control>
+              <Accordion.Panel>
+                {display.body}
+                {action && (
+                  <Group justify="flex-end" mt="sm">
+                    <Button size="xs" variant="light" onClick={() => void dispatch(action)}>
+                      查看
+                    </Button>
+                  </Group>
+                )}
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
+
+      {totalPages > 1 && (
+        <Group justify="center">
+          <Pagination
+            total={totalPages}
+            value={page}
+            onChange={handlePageChange}
+            size={small ? "sm" : "md"}
+          />
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+export default function Notifications() {
+  return (
+    <Page meta={{ title: "通知", description: "查看 maimai DX 查分器的系统通知与个人消息" }}>
+      <NotificationFeed />
+    </Page>
+  );
+}

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -1,0 +1,54 @@
+import { Game } from "@/types/game";
+
+export type NotificationCategory = "broadcast" | "personal";
+export type NotificationLevel = "normal" | "important" | "urgent";
+
+export type NotificationAction =
+  | { type: "link"; url: string }
+  | { type: "song"; game: Game; song_id: number };
+
+export interface NotificationProps {
+  id: number;
+  category: NotificationCategory;
+  type: string;
+  level: NotificationLevel;
+  title: string;
+  content: string;
+  action?: NotificationAction; // 跳转动作由前端定义
+  data?: Record<string, unknown>; // 仅个人通知
+  read: boolean;
+  create_time: string;
+  expire_time?: string;
+}
+
+export interface NotificationListResponse {
+  notifications: NotificationProps[];
+  total: number;
+  unread_count: number;
+}
+
+export interface NotificationImageUploadResponse {
+  url: string;
+}
+
+export interface PublishNotificationPayload {
+  title: string;
+  content: string;
+  type: string;
+  level: NotificationLevel;
+  expire_time?: string;
+  audience: { type: "all" | "permission" | "users"; permission?: number; user_ids?: number[] };
+}
+
+export interface AdminBroadcast {
+  id: number;
+  type: string;
+  level: NotificationLevel;
+  title: string;
+  content: string;
+  audience_type: "all" | "permission" | "users";
+  audience_permission?: number;
+  create_time: string;
+  update_time?: string;
+  expire_time?: string;
+}

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -5,7 +5,8 @@ export type NotificationLevel = "normal" | "important" | "urgent";
 
 export type NotificationAction =
   | { type: "link"; url: string }
-  | { type: "song"; game: Game; song_id: number };
+  | { type: "song"; game: Game; song_id: number }
+  | { type: "score"; game: Game; song_id: number; song_type?: string; difficulty: number };
 
 export interface NotificationProps {
   id: number;

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -39,6 +39,8 @@ export interface PublishNotificationPayload {
   level: NotificationLevel;
   expire_time?: string;
   audience: { type: "all" | "permission" | "users"; permission?: number; user_ids?: number[] };
+  // 常驻：绕过新用户基线，对发布后才注册的用户也可见（onboarding 公告）
+  persistent?: boolean;
 }
 
 export interface AdminBroadcast {
@@ -49,6 +51,7 @@ export interface AdminBroadcast {
   content: string;
   audience_type: "all" | "permission" | "users";
   audience_permission?: number;
+  persistent: boolean;
   create_time: string;
   update_time?: string;
   expire_time?: string;

--- a/src/utils/api/notification.ts
+++ b/src/utils/api/notification.ts
@@ -1,0 +1,29 @@
+import { fetchAPI, uploadFile } from "./api.ts";
+import { PublishNotificationPayload } from "@/types/notification";
+
+export async function markNotificationRead(category: string, id: number): Promise<Response> {
+  return fetchAPI("user/notifications/read", { method: "POST", body: { category, id } });
+}
+
+export async function markAllNotificationsRead(): Promise<Response> {
+  return fetchAPI("user/notifications/read-all", { method: "POST" });
+}
+
+export async function publishNotification(payload: PublishNotificationPayload): Promise<Response> {
+  return fetchAPI("user/admin/notifications", { method: "POST", body: payload });
+}
+
+export async function updateNotification(
+  id: number,
+  payload: PublishNotificationPayload,
+): Promise<Response> {
+  return fetchAPI(`user/admin/notifications/${id}`, { method: "PUT", body: payload });
+}
+
+export async function deleteNotification(id: number): Promise<Response> {
+  return fetchAPI(`user/admin/notifications/${id}`, { method: "DELETE" });
+}
+
+export async function uploadNotificationImage(file: File): Promise<Response> {
+  return uploadFile("user/admin/notifications/upload-image", file);
+}


### PR DESCRIPTION
## 概述

实现通知中心的前端：统一通知列表（广播 + 个人通知）、管理员发布端、紧急广播弹窗。需配合后端 `user/notifications*` 与 `user/admin/notifications*` 端点。

## 用户侧

- 侧边栏「通知」入口 + 未读 `Indicator` 红点（窗口聚焦刷新未读数）
- `/notifications` 页：`Accordion` 列表、全部/未读 `SegmentedControl`、展开即标记已读、按 `type` 出图标 / 按 `level` 上色
- 紧急广播进站 `Modal`（进/出场动画、「已弹过」记录、「我知道了」标记已读）
- 个人通知前端渲染文案（Discourse 风格：后端发 `data`、前端按 `type` 拼文案）：`developer_approved`、`alias_approved`；未知 `type` 有兜底
- 正文统一用 `Typography` 渲染（广播走 Markdown + rehype-raw；个人通知文本自动转义，无 XSS）
- 跳转动作 `link` / `song`（alias 深链曲目页）

## 管理侧（公告管理 Tab）

- 广播发布 / 编辑 / 删除（硬删；过期以标题样式体现）
- 类型 + 级别（Chip）+ 接收对象（全体 / 指定权限 / 指定用户）+ 过期时间
- 从用户表勾选用户「发送通知」，用户表新增权限筛选
- 正文插图改为上传（`useFileDialog` → 上传 → 插入返回 URL）

## 需要后端配合

- `user/notifications*`、`user/admin/notifications*` 系列端点
- 新增 `POST /api/v0/user/admin/notifications/upload-image`（管理员鉴权，multipart `file`，返回 `{ success, data: { url } }`）
- 个人通知 `data`：`developer_approved: { name }`、`alias_approved: { game, alias, song_id?, song_type?, difficulty? }`

## 其它

- 抽出共享组件 `FilterChips` / `NotificationTypeIcon` / `notificationIcons`
- 修复 `ScoreModal` 切 game 与开 Modal 同时发生时的 `songList` 竞态

## 验证

`yarn build`（tsc + vite，Node 24）通过；改动文件 `yarn lint` 无新增告警。本仓库无单测框架。

🤖 Generated with [Claude Code](https://claude.com/claude-code)