### PR TITLE
fix(overlay): 返回栈同 tick 批量结算,消除关遮罩层时的历史错位

### DIFF
--- a/src/components/Alias/CreateAliasModal.tsx
+++ b/src/components/Alias/CreateAliasModal.tsx
@@ -29,6 +29,7 @@ import { useAliasExists } from "@/hooks/queries/useAliasExists.ts";
 import { useBackDismiss } from "@/hooks/useBackDismiss.ts";
 import { APIError } from "@/utils/errors.ts";
 import { openAlertModal, openRetryModal } from "../../utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { SongCombobox } from "../SongCombobox.tsx";
 import { PhotoView } from "react-photo-view";
 import { MaimaiSongList, MaimaiSongProps } from "@/utils/api/song/maimai.ts";
@@ -117,7 +118,11 @@ export const CreateAliasModal = ({
       { game, data: values },
       {
         onSuccess: () => {
-          openAlertModal("别名创建成功", "快去邀请你的小伙伴投票吧。");
+          notifications.show({
+            title: "别名创建成功",
+            message: "快去邀请你的小伙伴投票吧。",
+            color: "green",
+          });
           form.resetField("alias");
           onClose(values);
         },

--- a/src/components/Developer/EditDeveloperModal.tsx
+++ b/src/components/Developer/EditDeveloperModal.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "@mantine/form";
 import { useUpdateDeveloperInfo } from "@/hooks/mutations/useDeveloperMutations.ts";
-import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import { openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { Button, Group, Modal, TextInput } from "@mantine/core";
 import { DeveloperProps } from "@/types/developer";
 import { validateText, validateUrl } from "@/utils/validator.ts";
@@ -65,7 +66,7 @@ export const EditDeveloperModal = ({
 
     updateDeveloperInfoMutation.mutate(transformedValues, {
       onSuccess: () => {
-        openAlertModal("修改成功", "开发者信息已更新。");
+        notifications.show({ title: "修改成功", message: "开发者信息已更新。", color: "green" });
         onSuccess();
         close();
       },

--- a/src/components/Profile/UserBindSection.tsx
+++ b/src/components/Profile/UserBindSection.tsx
@@ -4,7 +4,8 @@ import { Icon } from "@/components/MdiIcon";
 import { mdiEye, mdiEyeOff } from "@mdi/js";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./Profile.module.css";
-import { openAlertModal, openRetryModal } from "../../utils/modal.tsx";
+import { openRetryModal } from "../../utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { useUser } from "@/hooks/queries/useUser.ts";
 import { useUpdateUserBind } from "@/hooks/mutations/useUserMutations.ts";
 
@@ -34,7 +35,11 @@ export const UserBindSection = () => {
   const updateUserBindHandler = (values: TransformedValues<typeof form>) => {
     updateBind(values, {
       onSuccess: () => {
-        openAlertModal("绑定成功", "第三方开发者将可以通过绑定信息获取你的游戏数据。");
+        notifications.show({
+          title: "绑定成功",
+          message: "第三方开发者将可以通过绑定信息获取你的游戏数据。",
+          color: "green",
+        });
         setData((prev) =>
           prev ? { ...prev, bind: { ...(prev.bind || {}), qq: values.qq as number } } : prev,
         );

--- a/src/components/Profile/UserSection.tsx
+++ b/src/components/Profile/UserSection.tsx
@@ -6,7 +6,8 @@ import { TransformedValues, useForm } from "@mantine/form";
 import { validateEmail, validateUserName } from "@/utils/validator";
 import { useUpdateUserProfile } from "@/hooks/mutations/useUserMutations.ts";
 import classes from "./Profile.module.css";
-import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import { openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { useUser } from "@/hooks/queries/useUser.ts";
 
 interface FormValues {
@@ -48,7 +49,11 @@ export const UserSection = () => {
   const updateUserProfileHandler = (values: TransformedValues<typeof form>) => {
     mutateUpdateProfile(values, {
       onSuccess: () => {
-        openAlertModal("保存成功", "你的账号详情保存成功。");
+        notifications.show({
+          title: "保存成功",
+          message: "你的账号详情保存成功。",
+          color: "green",
+        });
         setData((prev) =>
           prev
             ? {

--- a/src/components/Scores/ScoreModalMenu.tsx
+++ b/src/components/Scores/ScoreModalMenu.tsx
@@ -1,9 +1,10 @@
-import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
 import {
   useDeletePlayerScore,
   useDeletePlayerScoreHistory,
 } from "@/hooks/mutations/usePlayerMutations.ts";
 import { ActionIcon, Menu } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import classes from "./ScoreModalMenu.module.css";
 import {
   IconClearAll,
@@ -48,7 +49,11 @@ export const ScoreModalMenu = ({ score, difficulty, onClose }: ScoreModalActionM
       { game, params },
       {
         onSuccess: () => {
-          openAlertModal("成绩删除成功", "你的成绩已经成功删除。");
+          notifications.show({
+            title: "成绩删除成功",
+            message: "你的成绩已经成功删除。",
+            color: "green",
+          });
           onClose && onClose(score);
         },
         onError: (err) => {
@@ -63,7 +68,11 @@ export const ScoreModalMenu = ({ score, difficulty, onClose }: ScoreModalActionM
       { game, params },
       {
         onSuccess: () => {
-          openAlertModal("成绩删除成功", "你的所有历史成绩已经成功删除。");
+          notifications.show({
+            title: "成绩删除成功",
+            message: "你的所有历史成绩已经成功删除。",
+            color: "green",
+          });
           onClose && onClose(score);
         },
         onError: (err) => {

--- a/src/components/Scores/chunithm/CreateScoreModal.tsx
+++ b/src/components/Scores/chunithm/CreateScoreModal.tsx
@@ -15,8 +15,9 @@ import { useEffect, useState } from "react";
 import { TransformedValues, useForm } from "@mantine/form";
 import { useComputedColorScheme } from "@mantine/core";
 import { ChunithmDifficultyProps, ChunithmSongProps } from "@/utils/api/song/chunithm.ts";
-import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
 import { DatesProvider, DateTimePicker } from "@mantine/dates";
+import { notifications } from "@mantine/notifications";
 import { useCreatePlayerScores } from "@/hooks/mutations/usePlayerMutations.ts";
 import { SongCombobox } from "../../SongCombobox.tsx";
 import "dayjs/locale/zh-cn";
@@ -97,7 +98,11 @@ export const ChunithmCreateScoreModalContent = ({
       { game: "chunithm", scores: [values] },
       {
         onSuccess: () => {
-          openAlertModal("成绩创建成功", "你的成绩已经成功创建。");
+          notifications.show({
+            title: "成绩创建成功",
+            message: "你的成绩已经成功创建。",
+            color: "green",
+          });
           form.setValues({
             id: null,
             difficulty: null,

--- a/src/components/Scores/maimai/CreateScoreModal.tsx
+++ b/src/components/Scores/maimai/CreateScoreModal.tsx
@@ -19,8 +19,9 @@ import {
   MaimaiDifficultiesProps,
   MaimaiSongProps,
 } from "@/utils/api/song/maimai.ts";
-import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
 import { DatesProvider, DateTimePicker } from "@mantine/dates";
+import { notifications } from "@mantine/notifications";
 import { useCreatePlayerScores } from "@/hooks/mutations/usePlayerMutations.ts";
 import { SongCombobox } from "../../SongCombobox.tsx";
 import "dayjs/locale/zh-cn";
@@ -98,7 +99,11 @@ export const MaimaiCreateScoreContent = ({ score, onSubmit, onClose }: CreateSco
       { game: "maimai", scores: [values] },
       {
         onSuccess: () => {
-          openAlertModal("成绩创建成功", "你的成绩已经成功创建。");
+          notifications.show({
+            title: "成绩创建成功",
+            message: "你的成绩已经成功创建。",
+            color: "green",
+          });
           form.setValues({
             id: null,
             type: null,

--- a/src/components/Settings/EditPasswordModal.tsx
+++ b/src/components/Settings/EditPasswordModal.tsx
@@ -1,7 +1,8 @@
 import { useForm } from "@mantine/form";
 import { validatePassword } from "@/utils/validator.ts";
 import { useEditUserPassword } from "@/hooks/mutations/useUserMutations.ts";
-import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import { openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { Button, Group, Modal, PasswordInput } from "@mantine/core";
 
 interface FormValues {
@@ -38,7 +39,11 @@ export const EditPasswordModal = ({ opened, close }: { opened: boolean; close():
   const editUserPasswordHandler = (values: FormValues) => {
     mutateEditPassword(values, {
       onSuccess: () => {
-        openAlertModal("修改成功", "下次登录时请使用新密码。");
+        notifications.show({
+          title: "修改成功",
+          message: "下次登录时请使用新密码。",
+          color: "green",
+        });
       },
       onError: (err) => {
         openRetryModal("修改失败", `${err}`, () => editUserPasswordHandler(values));

--- a/src/components/Settings/PasskeyManagement.tsx
+++ b/src/components/Settings/PasskeyManagement.tsx
@@ -23,6 +23,7 @@ import {
   getPasskeyRegisterChallenge,
 } from "@/utils/api/user";
 import { openAlertModal, openConfirmModal, openRetryModal, openFormModal } from "@/utils/modal";
+import { notifications } from "@mantine/notifications";
 import type { PasskeyProps, PasskeyRegisterData } from "@/types/user";
 import classes from "./Settings.module.css";
 import { startRegistration } from "@simplewebauthn/browser";
@@ -98,7 +99,11 @@ export const PasskeyManagement = () => {
         return;
       }
 
-      openAlertModal("注册成功", "通行密钥已成功添加到你的账号。");
+      notifications.show({
+        title: "注册成功",
+        message: "通行密钥已成功添加到你的账号。",
+        color: "green",
+      });
       await loadPasskeys();
     } catch (error) {
       if ((error as Error).name === "NotAllowedError") {

--- a/src/pages/admin/Panel/users/AdminUsersSection.tsx
+++ b/src/pages/admin/Panel/users/AdminUsersSection.tsx
@@ -5,7 +5,8 @@ import { useDisclosure, useViewportSize } from "@mantine/hooks";
 import { DataTable, DataTableSortStatus } from "mantine-datatable";
 import { IconDatabaseOff, IconSearch, IconSend, IconTrash } from "@tabler/icons-react";
 import classes from "@/pages/Page.module.css";
-import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { EditUserModal } from "@/components/Users/EditUserModal.tsx";
 import { SendBatchEmailModal } from "@/components/Users/SendBatchEmailModal.tsx";
 import { permissionToList, UserPermission } from "@/utils/session.ts";
@@ -120,7 +121,11 @@ const AdminUsersContent = () => {
       if (!data.success) {
         throw new Error(data.message);
       }
-      openAlertModal("删除成功", `所选的 ${selectedUsers.length} 名用户已经被删除。`);
+      notifications.show({
+        title: "删除成功",
+        message: `所选的 ${selectedUsers.length} 名用户已经被删除。`,
+        color: "green",
+      });
       selectedUsers.forEach((user) => {
         const index = users.findIndex((u) => u.id === user.id);
         users.splice(index, 1);

--- a/src/pages/admin/Settings/workers/WorkersSection.tsx
+++ b/src/pages/admin/Settings/workers/WorkersSection.tsx
@@ -33,6 +33,7 @@ import { useViewportSize } from "@mantine/hooks";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createWorker, updateWorker, deleteWorker } from "@/utils/api/admin.ts";
 import { openConfirmModal, openRetryModal, openFormModal, openAlertModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import classes from "@/pages/Page.module.css";
 import workerClasses from "./WorkersSection.module.css";
 
@@ -292,7 +293,11 @@ export const WorkersSection = () => {
               throw new Error(data.message || "删除失败");
             }
           }
-          openAlertModal("删除成功", `所选的 ${selectedWorkers.length} 个工作节点已被删除。`);
+          notifications.show({
+            title: "删除成功",
+            message: `所选的 ${selectedWorkers.length} 个工作节点已被删除。`,
+            color: "green",
+          });
           setSelectedWorkers([]);
           invalidate();
         } catch (error) {

--- a/src/pages/developer/Apply.tsx
+++ b/src/pages/developer/Apply.tsx
@@ -14,7 +14,8 @@ import { Icon } from "@/components/MdiIcon";
 import { mdiCodeTags, mdiLink } from "@mdi/js";
 import { useForm } from "@mantine/form";
 import classes from "../Form.module.css";
-import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import { openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { validateText, validateUrl } from "@/utils/validator.ts";
 import { useDeveloper } from "@/hooks/queries/useDeveloper.ts";
 import { useSendDeveloperApply } from "@/hooks/mutations/useDeveloperMutations.ts";
@@ -58,7 +59,11 @@ export default function DeveloperApply() {
     sendApply(values, {
       onSuccess: () => {
         setApplied(true);
-        openAlertModal("提交成功", "申请成功，我们将尽快审核您的申请。");
+        notifications.show({
+          title: "提交成功",
+          message: "申请成功，我们将尽快审核您的申请。",
+          color: "green",
+        });
       },
       onError: (error) => {
         openRetryModal("提交失败", `${error}`, () => handleSubmit(values));

--- a/src/pages/public/ForgotPassword.tsx
+++ b/src/pages/public/ForgotPassword.tsx
@@ -18,7 +18,8 @@ import { Link } from "@/components/Link";
 import { useForm } from "@mantine/form";
 import { IconArrowLeft, IconMail } from "@tabler/icons-react";
 import classes from "../Form.module.css";
-import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
+import { openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { useForgotPassword } from "@/hooks/mutations/useAuthMutations.ts";
 
 interface FormValues {
@@ -49,7 +50,11 @@ export default function ForgotPassword() {
         { values, captchaToken },
         {
           onSuccess: () => {
-            openAlertModal("发送成功", "请前往你的邮箱查看重置邮件。");
+            notifications.show({
+              title: "发送成功",
+              message: "请前往你的邮箱查看重置邮件。",
+              color: "green",
+            });
           },
           onError: (error) => {
             openRetryModal("发送失败", `${error}`, () => forgotPasswordHandler(values));

--- a/src/pages/user/Settings/GeneralSettingsSection.tsx
+++ b/src/pages/user/Settings/GeneralSettingsSection.tsx
@@ -2,7 +2,8 @@ import { Text, Card, LoadingOverlay, Mark } from "@mantine/core";
 import { SettingList, SettingValue } from "@/components/Settings/SettingList.tsx";
 import { Link } from "@/components/Link";
 import classes from "../../Page.module.css";
-import { openAlertModal, openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
+import { notifications } from "@mantine/notifications";
 import { useUserConfig } from "@/hooks/queries/useUserConfig.ts";
 import useGame from "@/hooks/useGame.ts";
 import { Anchor } from "@mantine/core";
@@ -254,10 +255,11 @@ export const GeneralSettingsSection = () => {
   const unbindPlayerHandler = () => {
     unbindPlayerMutate(game, {
       onSuccess: () => {
-        openAlertModal(
-          "解绑成功",
-          `你的「${game === "chunithm" ? "中二节奏" : "舞萌 DX"}」账号已经被解绑。`,
-        );
+        notifications.show({
+          title: "解绑成功",
+          message: `你的「${game === "chunithm" ? "中二节奏" : "舞萌 DX"}」账号已经被解绑。`,
+          color: "green",
+        });
       },
       onError: (error) => {
         openRetryModal("解绑失败", `${error}`, unbindPlayerHandler);
@@ -268,10 +270,11 @@ export const GeneralSettingsSection = () => {
   const deletePlayerScoresHandler = () => {
     deleteScoresMutate(game, {
       onSuccess: () => {
-        openAlertModal(
-          "删除成功",
-          `你的查分器账号里所有的「${game === "chunithm" ? "中二节奏" : "舞萌 DX"}」谱面成绩已经被删除。`,
-        );
+        notifications.show({
+          title: "删除成功",
+          message: `你的查分器账号里所有的「${game === "chunithm" ? "中二节奏" : "舞萌 DX"}」谱面成绩已经被删除。`,
+          color: "green",
+        });
       },
       onError: (error) => {
         openRetryModal("删除失败", `${error}`, deletePlayerScoresHandler);

--- a/src/pages/user/Sync/ProxySyncSection.tsx
+++ b/src/pages/user/Sync/ProxySyncSection.tsx
@@ -31,6 +31,7 @@ import {
 } from "@tabler/icons-react";
 import { navigate } from "vike/client/router";
 import { openAlertModal } from "@/utils/modal";
+import { notifications } from "@mantine/notifications";
 import { checkProxy } from "@/utils/checkProxy.ts";
 import { getUserCrawlToken } from "@/utils/api/user.ts";
 import { API_URL } from "@/utils/api/api.ts";
@@ -207,7 +208,11 @@ export const ProxySyncSection = () => {
               setStep(2);
             } else if (status.status === "completed") {
               setStep(3);
-              openAlertModal("同步游戏数据成功", "你的游戏数据已成功同步到 maimai DX 查分器。");
+              notifications.show({
+                title: "同步游戏数据成功",
+                message: "你的游戏数据已成功同步到 maimai DX 查分器。",
+                color: "green",
+              });
             } else if (status.status === "failed") {
               setStep(3);
               openAlertModal(

--- a/src/utils/overlayBackStack.ts
+++ b/src/utils/overlayBackStack.ts
@@ -5,6 +5,9 @@ let pendingProgrammaticPops = 0;
 let listenerInstalled = false;
 let nextId = 1;
 
+let netDepthDelta = 0;
+let settleScheduled = false;
+
 function handlePopState() {
   if (pendingProgrammaticPops > 0) {
     pendingProgrammaticPops -= 1;
@@ -20,11 +23,35 @@ function ensureListener() {
   listenerInstalled = true;
 }
 
+function settle() {
+  settleScheduled = false;
+  const delta = netDepthDelta;
+  netDepthDelta = 0;
+  if (delta === 0 || typeof window === "undefined") return;
+  if (delta > 0) {
+    for (let i = 0; i < delta; i++) {
+      window.history.pushState({ __overlayBack: true }, "");
+    }
+  } else {
+    pendingProgrammaticPops += -delta;
+    for (let i = 0; i < -delta; i++) {
+      window.history.back();
+    }
+  }
+}
+
+function scheduleSettle() {
+  if (settleScheduled) return;
+  settleScheduled = true;
+  queueMicrotask(settle);
+}
+
 export function pushOverlay(close: () => void): number {
   ensureListener();
   const id = nextId++;
   stack.push({ id, close });
-  window.history.pushState({ __overlayBack: true }, "");
+  netDepthDelta += 1;
+  scheduleSettle();
   return id;
 }
 
@@ -32,6 +59,6 @@ export function popOverlay(id: number): void {
   const index = stack.findIndex((entry) => entry.id === id);
   if (index === -1) return;
   stack.splice(index, 1);
-  pendingProgrammaticPops += 1;
-  window.history.back();
+  netDepthDelta -= 1;
+  scheduleSettle();
 }


### PR DESCRIPTION
overlayBackStack 的 pushOverlay/popOverlay 原先各自立即操作 window.history(pushState / back)。当同一 React 提交里同时"关一个 遮罩层 + 开另一个"(如删除成绩成功:关成绩 modal + 开提示弹窗)时,
异步 back() 与同步 pushState 交错,产生孤立哨兵,用户关闭提示弹窗时
再 back() 一次即越过当前页面,表现为回退到上一页。

改为只更新内存栈并累加 netDepthDelta,通过 queueMicrotask 延迟结算:
同一微任务内的所有 push/pop 合并为一次净深度变化,净 0 则不动 history。
"关一个 + 开一个"净变化为 0,零 history 操作,竞态从根上消除。
所有同类触发点(删除/创建成绩、创建别名等)一并修复,调用方无需改动。

同时将纯成功告知由 openAlertModal 改为 notifications.show(toast), 避免占用返回栈且体验更轻;需交互/复制的弹窗(确认、重试、Token 展示等)
保持不变。

Closes #49