### PR TITLE
fix: 修正中二节奏分数构成页面Rating计算错误

### DIFF
--- a/src/components/Scores/RatingConstantAnalysis.tsx
+++ b/src/components/Scores/RatingConstantAnalysis.tsx
@@ -141,11 +141,11 @@ export function RatingConstantAnalysis({
     }
     const b30avg = average((bests.bests ?? []).map((s) => s.rating));
     const n20avg = average((bests.new_bests ?? []).map((s) => s.rating));
-    const b30count = + (bests.bests?.length ?? 0);
-    const n20count = + (bests.new_bests?.length ?? 0);
+    const b30count = +(bests.bests?.length ?? 0);
+    const n20count = +(bests.new_bests?.length ?? 0);
     const bestsCount = b30count + n20count;
     total = truncate2(
-      (b30avg * (b30count / bestsCount)) + (n20avg * (n20count / bestsCount))
+      b30avg * (b30count / bestsCount) + n20avg * (n20count / bestsCount),
     );
   }
 

--- a/src/components/Scores/RatingConstantAnalysis.tsx
+++ b/src/components/Scores/RatingConstantAnalysis.tsx
@@ -1,8 +1,20 @@
-import { Accordion, Badge, Center, Group, Image, Paper, Stack, Text } from "@mantine/core";
+import {
+  Accordion,
+  Badge,
+  Center,
+  Group,
+  Image,
+  Paper,
+  Stack,
+  Text,
+} from "@mantine/core";
 import { DataTable, DataTableColumn } from "mantine-datatable";
 import classes from "./RatingConstantAnalysis.module.css";
 import { ChunithmBestsProps, MaimaiBestsProps } from "@/types/score";
-import { requiredChunithmConstant, requiredMaimaiConstant } from "@/utils/rating.ts";
+import {
+  requiredChunithmConstant,
+  requiredMaimaiConstant,
+} from "@/utils/rating.ts";
 import { getDeluxeRatingGradient, getRatingGradient } from "@/utils/color.ts";
 
 interface AnalysisRow {
@@ -24,7 +36,9 @@ function truncate2(value: number): number {
 
 function truncate2Average(values: number[]): number {
   if (values.length === 0) return 0;
-  return truncate2(values.reduce((acc, v) => acc + truncate2(v), 0) / values.length);
+  return truncate2(
+    values.reduce((acc, v) => acc + truncate2(v), 0) / values.length,
+  );
 }
 
 function average(values: number[]): number {
@@ -32,7 +46,9 @@ function average(values: number[]): number {
   return values.reduce((acc, v) => acc + truncate2(v), 0) / values.length;
 }
 
-function isMaimaiBests(bests: MaimaiBestsProps | ChunithmBestsProps): bests is MaimaiBestsProps {
+function isMaimaiBests(
+  bests: MaimaiBestsProps | ChunithmBestsProps,
+): bests is MaimaiBestsProps {
   return "standard_total" in bests && "dx_total" in bests;
 }
 
@@ -59,15 +75,22 @@ export function RatingConstantAnalysis({
   const maimai = isMaimaiBests(bests);
   const ranks = maimai ? MAIMAI_RANKS : CHUNITHM_RANKS;
   const maxConstant = maimai ? 15 : 16;
-  const fmtRating = (r: number) => (maimai ? String(Math.round(r)) : truncate2(r).toFixed(2));
+  const fmtRating = (r: number) =>
+    maimai ? String(Math.round(r)) : truncate2(r).toFixed(2);
   const requiredFor = (rating: number, index: number) =>
     maimai
       ? requiredMaimaiConstant(rating, MAIMAI_RANKS[index].achievement)
       : requiredChunithmConstant(rating, CHUNITHM_RANKS[index].offset);
   const rankImage = (id: string) =>
-    maimai ? `/assets/maimai/music_rank/${id}.webp` : `/assets/chunithm/music_rank/${id}_s.webp`;
+    maimai
+      ? `/assets/maimai/music_rank/${id}.webp`
+      : `/assets/chunithm/music_rank/${id}_s.webp`;
 
-  const buildSegment = (title: string, ratings: number[], totalRaw: number): AnalysisSegment => {
+  const buildSegment = (
+    title: string,
+    ratings: number[],
+    totalRaw: number,
+  ): AnalysisSegment => {
     const max = ratings.length > 0 ? ratings[0] : 0;
     const min = ratings.length > 0 ? ratings[ratings.length - 1] : 0;
     const buildRow = (label: string, rating: number): AnalysisRow => ({
@@ -75,13 +98,17 @@ export function RatingConstantAnalysis({
       rating: fmtRating(rating),
       values: ranks.map((_, index) => {
         const required = requiredFor(rating, index);
-        return rating > 0 && required <= maxConstant ? required.toFixed(1) : "-";
+        return rating > 0 && required <= maxConstant
+          ? required.toFixed(1)
+          : "-";
       }),
     });
     return {
       title,
       avg: fmtRating(truncate2Average(ratings)),
-      total: maimai ? String(Math.round(totalRaw)) : truncate2(totalRaw).toFixed(2),
+      total: maimai
+        ? String(Math.round(totalRaw))
+        : truncate2(totalRaw).toFixed(2),
       rows: [buildRow("最高", max), buildRow("最低", min)],
     };
   };
@@ -141,11 +168,11 @@ export function RatingConstantAnalysis({
     }
     const b30avg = average((bests.bests ?? []).map((s) => s.rating));
     const n20avg = average((bests.new_bests ?? []).map((s) => s.rating));
-    const b30count = + (bests.bests?.length ?? 0);
-    const n20count = + (bests.new_bests?.length ?? 0);
+    const b30count = +(bests.bests?.length ?? 0);
+    const n20count = +(bests.new_bests?.length ?? 0);
     const bestsCount = b30count + n20count;
     total = truncate2(
-      (b30avg * (b30count / bestsCount)) + (n20avg * (n20count / bestsCount))
+      b30avg * (b30count / bestsCount) + n20avg * (n20count / bestsCount),
     );
   }
 
@@ -161,21 +188,21 @@ export function RatingConstantAnalysis({
       ),
     },
     { accessor: "rating", title: "RATING", textAlign: "center" },
-    ...ranks.map(
-      (rank, index): DataTableColumn<AnalysisRow> => ({
-        accessor: `v${index}`,
-        title: (
-          <Center>
-            <Image src={rankImage(rank.id)} h={20} w="auto" alt={rank.id} />
-          </Center>
-        ),
-        textAlign: "center",
-        render: (row) => row.values[index],
-      }),
-    ),
+    ...ranks.map((rank, index): DataTableColumn<AnalysisRow> => ({
+      accessor: `v${index}`,
+      title: (
+        <Center>
+          <Image src={rankImage(rank.id)} h={20} w="auto" alt={rank.id} />
+        </Center>
+      ),
+      textAlign: "center",
+      render: (row) => row.values[index],
+    })),
   ];
 
-  const gradient = maimai ? getDeluxeRatingGradient(total) : getRatingGradient(total);
+  const gradient = maimai
+    ? getDeluxeRatingGradient(total)
+    : getRatingGradient(total);
 
   return (
     <Paper withBorder radius="md" style={{ overflow: "hidden" }}>
@@ -199,7 +226,9 @@ export function RatingConstantAnalysis({
           <Accordion.Item
             key={segment.title}
             value={segment.title}
-            className={index === segments.length - 1 ? classes.lastItem : undefined}
+            className={
+              index === segments.length - 1 ? classes.lastItem : undefined
+            }
           >
             <Accordion.Control>
               <Group justify="space-between" wrap="nowrap" pr="md">

--- a/src/components/Scores/RatingConstantAnalysis.tsx
+++ b/src/components/Scores/RatingConstantAnalysis.tsx
@@ -22,9 +22,14 @@ function truncate2(value: number): number {
   return Math.floor(value * 100) / 100;
 }
 
-function average(values: number[]): number {
+function truncate2Average(values: number[]): number {
   if (values.length === 0) return 0;
   return truncate2(values.reduce((acc, v) => acc + truncate2(v), 0) / values.length);
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((acc, v) => acc + truncate2(v), 0) / values.length;
 }
 
 function isMaimaiBests(bests: MaimaiBestsProps | ChunithmBestsProps): bests is MaimaiBestsProps {
@@ -75,7 +80,7 @@ export function RatingConstantAnalysis({
     });
     return {
       title,
-      avg: fmtRating(average(ratings)),
+      avg: fmtRating(truncate2Average(ratings)),
       total: maimai ? String(Math.round(totalRaw)) : truncate2(totalRaw).toFixed(2),
       rows: [buildRow("最高", max), buildRow("最低", min)],
     };
@@ -137,7 +142,7 @@ export function RatingConstantAnalysis({
     const b30avg = average((bests.bests ?? []).map((s) => s.rating));
     const n20avg = average((bests.new_bests ?? []).map((s) => s.rating));
     total = truncate2(
-      (b30avg * (bests.bests?.length ?? 0) + n20avg * (bests.new_bests?.length ?? 0)) / 50,
+      (b30avg * (30 / 50)) + (n20avg * (20 / 50))
     );
   }
 

--- a/src/components/Scores/RatingConstantAnalysis.tsx
+++ b/src/components/Scores/RatingConstantAnalysis.tsx
@@ -141,8 +141,11 @@ export function RatingConstantAnalysis({
     }
     const b30avg = average((bests.bests ?? []).map((s) => s.rating));
     const n20avg = average((bests.new_bests ?? []).map((s) => s.rating));
+    const b30count = + (bests.bests?.length ?? 0);
+    const n20count = + (bests.new_bests?.length ?? 0);
+    const bestsCount = b30count + n20count;
     total = truncate2(
-      (b30avg * (30 / 50)) + (n20avg * (20 / 50))
+      (b30avg * (b30count / bestsCount)) + (n20avg * (n20count / bestsCount))
     );
   }
 


### PR DESCRIPTION
虽然无法得知游戏内具体的计算方式
但是可以确定以 b30平均值(每首歌以2位小数计算) 不截断、保留小数，直接 * 0.6 加上一样的 n20平均值 *0.4
的结果会和游戏内的rating完全一致

新增了一个不截断的平均值计算函数
将total rating计算改为 b30avg * 0.6 + n20avg * 0.4
保证计算无误
