### PR TITLE
feat: 接入 Umami 网站分析

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,5 @@
 VITE_API_URL=https://maimai.lxns.net/api/v0
 VITE_ASSET_URL=https://assets.lxns.net
 VITE_CAPTCHA_ENDPOINT=https://cap.lxns.net/338a981468/
+VITE_UMAMI_SCRIPT_URL=https://stats.lxns.net/script.js
+VITE_UMAMI_WEBSITE_ID=be14c058-ff65-4713-bb59-8bd60ef306c0

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
 export const API_URL = import.meta.env.VITE_API_URL;
 export const ASSET_URL = import.meta.env.VITE_ASSET_URL;
 export const CAPTCHA_ENDPOINT = import.meta.env.VITE_CAPTCHA_ENDPOINT;
+export const UMAMI_SCRIPT_URL = import.meta.env.VITE_UMAMI_SCRIPT_URL;
+export const UMAMI_WEBSITE_ID = import.meta.env.VITE_UMAMI_WEBSITE_ID;

--- a/src/pages/+Head.tsx
+++ b/src/pages/+Head.tsx
@@ -1,4 +1,5 @@
 import { ColorSchemeScript } from "@mantine/core";
+import { UMAMI_SCRIPT_URL, UMAMI_WEBSITE_ID } from "../main.ts";
 
 const chunkRecoveryScript = `
 (function () {
@@ -83,6 +84,9 @@ export default function Head() {
   return (
     <>
       <script dangerouslySetInnerHTML={{ __html: chunkRecoveryScript }} />
+      {UMAMI_SCRIPT_URL && UMAMI_WEBSITE_ID && (
+        <script defer src={UMAMI_SCRIPT_URL} data-website-id={UMAMI_WEBSITE_ID} />
+      )}
       <ColorSchemeScript defaultColorScheme="auto" />
       <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       <link rel="manifest" href="/manifest.webmanifest" />

--- a/src/pages/+Head.tsx
+++ b/src/pages/+Head.tsx
@@ -1,5 +1,5 @@
 import { ColorSchemeScript } from "@mantine/core";
-import { UMAMI_SCRIPT_URL, UMAMI_WEBSITE_ID } from "../main.ts";
+import { UMAMI_SCRIPT_URL, UMAMI_WEBSITE_ID } from "@/main";
 
 const chunkRecoveryScript = `
 (function () {


### PR DESCRIPTION
## 概述

接入 [Umami](https://umami.is/)(开源、隐私友好、可自托管的网站分析平台),用于了解页面访问情况。作为 Amplitude 等商业分析平台的轻量替代,数据自托管、不出境、无 cookie。

## 改动

| 文件 | 改动 |
|------|------|
| `src/main.ts` | 新增导出 `UMAMI_SCRIPT_URL`、`UMAMI_WEBSITE_ID` 两个环境变量 |
| `src/pages/+Head.tsx` | 两个变量都配置时才注入 `<script defer src data-website-id>` |
| `.env.production` | 填入生产环境值(`stats.lxns.net` + website id) |

## 特性

- **可选、默认关闭**:仅当 `VITE_UMAMI_SCRIPT_URL` 与 `VITE_UMAMI_WEBSITE_ID` 均配置时才加载脚本。本地开发和自部署者不配这两个变量即完全不引入 Umami,不受影响。
- **仅页面浏览**:暂不埋自定义事件。Umami 自动追踪页面访问、来源、地区、设备,SPA 路由切换自动 hook。以后如需追踪具体动作可单独增量添加。
- **与 Sentry 独立**:两个脚本互不影响。

## 验证说明

CI 环境的包管理器 registry 被代理拦截,未能在自动化环境跑 `tsc`/`build`。改动均沿用项目既有写法(env 变量用法与现有三个变量一致;`<script>` 注入与既有 chunk 恢复脚本同处),建议合并前在本地或 CI 跑一次 `yarn build` 确认。

## 上线前需确认

- `stats.lxns.net` 反代已指向 Umami 实例,`https://stats.lxns.net/script.js` 可正常访问
- 生产 build 部署后,Umami 后台 Realtime 能看到数据进入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDbAn3w36xWUArUdBvYPbw)_