### PR TITLE
修复移动端侧栏手势冲突

### DIFF
--- a/src/components/Shell/Shell.tsx
+++ b/src/components/Shell/Shell.tsx
@@ -37,10 +37,6 @@ export default function Shell({ navbarOpened, onNavbarToggle, viewportRef, child
   }, [scrollState.y]);
 
   useEffect(() => {
-    setScrollDirection("up");
-  }, [navbarOpened]);
-
-  useEffect(() => {
     if (!scrollDirection) return;
 
     let frameRequest = 0;

--- a/src/pages/+Layout.tsx
+++ b/src/pages/+Layout.tsx
@@ -23,7 +23,6 @@ import { Fallback } from "@/pages/public/Fallback.tsx";
 import { PhotoProvider } from "react-photo-view";
 import { useFullscreenDocument } from "@mantine/hooks";
 import { useShallow } from "zustand/react/shallow";
-import useTouchEvents from "beautiful-react-hooks/useTouchEvents";
 import Shell from "@/components/Shell/Shell.tsx";
 import useSongListStore from "@/hooks/useSongListStore.ts";
 import useAliasListStore from "@/hooks/useAliasListStore.ts";
@@ -86,24 +85,6 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
   const viewport = useRef<HTMLDivElement>(null);
 
   useVersionChecker();
-
-  const ref = useRef<HTMLDivElement>(null);
-  const { onTouchStart, onTouchEnd } = useTouchEvents(ref as React.RefObject<HTMLDivElement>);
-  const [touchStartX, setTouchStartX] = useState(0);
-
-  onTouchStart((event: TouchEvent) => {
-    setTouchStartX(event.touches[0].clientX);
-  });
-
-  onTouchEnd((event: TouchEvent) => {
-    if (touchStartX / window.innerWidth > 0.1) return;
-
-    const touchEndX = event.changedTouches[0].clientX;
-
-    if (touchEndX - touchStartX > 100) {
-      setOpened(true);
-    }
-  });
 
   const toggleNavbarOpened = () => {
     if (window.innerWidth <= NAVBAR_BREAKPOINT) setOpened(!opened);
@@ -213,7 +194,6 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
                 viewportRef={viewport as React.RefObject<HTMLDivElement>}
               >
                 <div
-                  ref={ref}
                   style={{
                     minHeight: "calc(100vh - var(--header-height))",
                   }}


### PR DESCRIPTION
## 改动说明

移除与移动端系统返回手势冲突的网页左边缘滑动入口，并避免侧栏开关时强制展开顶部游戏切换栏造成布局抖动。

## 主要改动

- 移除全局布局中的侧栏边缘滑动识别及相关状态
- 保留汉堡菜单与遮罩层的侧栏开关方式
- 侧栏开关不再修改顶部栏滚动状态，避免动画期间高度重排

## 验证

- `yarn build`
- `yarn eslint src/pages/+Layout.tsx src/components/Shell/Shell.tsx --quiet`
- `yarn oxfmt --check src/pages/+Layout.tsx src/components/Shell/Shell.tsx`
- `git diff --check`
- 移动端实机验证侧栏交互正常
