### PR TITLE
fix: 加固认证会话与通知安全

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run --config vitest.config.ts",
     "stylelint": "stylelint ./src/**/*.css --cache",
     "preview": "vite preview"
   },
@@ -72,6 +73,7 @@
     "recharts": "3.8.1",
     "rehype-autolink-headings": "7.1.0",
     "rehype-raw": "7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-slug": "6.0.0",
     "remark": "15.0.1",
     "remark-flexible-containers": "1.5.3",
@@ -106,7 +108,8 @@
     "postcss-preset-mantine": "1.18.0",
     "postcss-simple-vars": "7.0.1",
     "typescript": "5.9.3",
-    "vite": "8.0.8"
+    "vite": "8.0.8",
+    "vitest": "^4.1.10"
   },
   "resolutions": {
     "prosemirror-model": "1.25.9"

--- a/src/components/Notifications/NotificationMarkdown.tsx
+++ b/src/components/Notifications/NotificationMarkdown.tsx
@@ -1,0 +1,33 @@
+import Markdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+
+const notificationSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...new Set([...(defaultSchema.tagNames ?? []), "mark", "u"])],
+};
+
+const notificationMarkdownComponents: Components = {
+  img: ({ src, alt, title }) => (
+    <img
+      src={src}
+      alt={alt ?? ""}
+      title={title}
+      loading="lazy"
+      style={{ maxWidth: "100%", height: "auto" }}
+    />
+  ),
+};
+
+export function NotificationMarkdown({ content }: { content: string }) {
+  return (
+    <Markdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, notificationSanitizeSchema]]}
+      components={notificationMarkdownComponents}
+    >
+      {content}
+    </Markdown>
+  );
+}

--- a/src/components/Notifications/notificationTemplates.test.tsx
+++ b/src/components/Notifications/notificationTemplates.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { getNotificationDisplay } from "./notificationTemplates.tsx";
+
+describe("broadcast notification rendering", () => {
+  it("removes active embedded content while preserving safe formatting", () => {
+    const display = getNotificationDisplay({
+      id: 1,
+      category: "broadcast",
+      type: "system",
+      level: "normal",
+      title: "测试通知",
+      content:
+        '<iframe srcdoc="<script>parent.localStorage.clear()</script>"></iframe><strong>安全内容</strong>',
+      read: false,
+      create_time: "2026-07-17T00:00:00.000Z",
+    });
+
+    const html = renderToStaticMarkup(<MantineProvider>{display.body}</MantineProvider>);
+
+    expect(html).toContain("<strong>安全内容</strong>");
+    expect(html).not.toContain("iframe");
+    expect(html).not.toContain("srcdoc");
+    expect(html).not.toContain("script");
+  });
+
+  it("preserves editor formatting and constrains notification images", () => {
+    const display = getNotificationDisplay({
+      id: 2,
+      category: "broadcast",
+      type: "system",
+      level: "normal",
+      title: "格式测试",
+      content:
+        '<mark>高亮</mark><u>下划线</u><img src="https://example.com/image.png" alt="通知配图" style="position:fixed;max-width:none">',
+      read: false,
+      create_time: "2026-07-17T00:00:00.000Z",
+    });
+
+    const html = renderToStaticMarkup(<MantineProvider>{display.body}</MantineProvider>);
+
+    expect(html).toContain("<mark>高亮</mark>");
+    expect(html).toContain("<u>下划线</u>");
+    expect(html).toContain('alt="通知配图"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain("max-width:100%");
+    expect(html).not.toContain("position:fixed");
+  });
+});

--- a/src/components/Notifications/notificationTemplates.tsx
+++ b/src/components/Notifications/notificationTemplates.tsx
@@ -1,10 +1,8 @@
 import { ReactNode } from "react";
 import { Typography } from "@mantine/core";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
 import { Game } from "@/types/game";
 import { NotificationAction, NotificationProps } from "@/types/notification";
+import { NotificationMarkdown } from "./NotificationMarkdown.tsx";
 
 export interface NotificationDisplay {
   title: string;
@@ -76,11 +74,7 @@ const templates: Record<string, NotificationTemplate> = {
 };
 
 function renderContent(content: string): ReactNode {
-  return (
-    <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-      {content}
-    </Markdown>
-  );
+  return <NotificationMarkdown content={content} />;
 }
 
 export function getNotificationDisplay(n: NotificationProps): NotificationDisplay {

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -1,7 +1,8 @@
 import { navigate } from "vike/client/router";
-import { isTokenUndefined, isTokenExpired, checkPermission, UserPermission } from "@/utils/session";
+import { isTokenExpired, checkPermission, UserPermission } from "@/utils/session";
 import { useUserToken } from "@/hooks/queries/useUserToken.ts";
 import { useEffect, useState } from "react";
+import { isAuthenticationRefreshError } from "@/utils/api/api.ts";
 
 interface GuardProps {
   children: React.ReactNode;
@@ -9,34 +10,65 @@ interface GuardProps {
 }
 
 export function RouteGuard({ children, requireAdmin = false }: GuardProps) {
-  const { refetch } = useUserToken();
+  const { token, refetch } = useUserToken();
   const [isChecking, setIsChecking] = useState(true);
   const [isAllowed, setIsAllowed] = useState(false);
+  const [verificationError, setVerificationError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    let cancelled = false;
+
+    const verifySession = async () => {
+      if (typeof window === "undefined") {
+        setIsChecking(false);
+        return;
+      }
+
+      setIsChecking(true);
+      setIsAllowed(false);
+      setVerificationError(null);
+
+      if (!token) {
+        const redirectPath = encodeURIComponent(
+          window.location.pathname + window.location.search + window.location.hash,
+        );
+        navigate(`/login?redirect=${redirectPath}`);
+        return;
+      }
+
+      if (isTokenExpired()) {
+        const result = await refetch();
+        if (cancelled) return;
+        if (result.error) {
+          if (isAuthenticationRefreshError(result.error)) {
+            const redirectPath = encodeURIComponent(
+              window.location.pathname + window.location.search + window.location.hash,
+            );
+            navigate(`/login?redirect=${redirectPath}`);
+          } else {
+            setVerificationError(result.error);
+            setIsChecking(false);
+          }
+          return;
+        }
+      }
+
+      if (requireAdmin && !checkPermission(UserPermission.Administrator)) {
+        navigate("/");
+        return;
+      }
+
+      setIsAllowed(true);
       setIsChecking(false);
-      return;
-    }
+    };
 
-    if (isTokenUndefined()) {
-      const redirectPath = encodeURIComponent(window.location.pathname + window.location.search);
-      navigate(`/login?redirect=${redirectPath}`);
-      return;
-    }
+    void verifySession();
+    return () => {
+      cancelled = true;
+    };
+  }, [refetch, requireAdmin, token]);
 
-    if (isTokenExpired()) {
-      refetch();
-    }
-
-    if (requireAdmin && !checkPermission(UserPermission.Administrator)) {
-      navigate("/");
-      return;
-    }
-
-    setIsAllowed(true);
-    setIsChecking(false);
-  }, [refetch, requireAdmin]);
+  if (verificationError) throw verificationError;
 
   if (isChecking) {
     return null;

--- a/src/components/Settings/EditPasswordModal.tsx
+++ b/src/components/Settings/EditPasswordModal.tsx
@@ -5,7 +5,7 @@ import { openRetryModal } from "@/utils/modal.tsx";
 import { notifications } from "@mantine/notifications";
 import { Button, Group, Modal, PasswordInput } from "@mantine/core";
 import * as Sentry from "@sentry/react";
-import { getSentryUser } from "@/utils/session.ts";
+import { getSentryUser, setAuthToken } from "@/utils/session.ts";
 
 interface FormValues {
   current_password: string;
@@ -40,9 +40,9 @@ export const EditPasswordModal = ({ opened, close }: { opened: boolean; close():
 
   const editUserPasswordHandler = (values: FormValues) => {
     mutateEditPassword(values, {
-      onSuccess: (data) => {
+      onSuccess: async (data) => {
         if (data?.token) {
-          localStorage.setItem("token", data.token);
+          await setAuthToken(data.token);
           Sentry.setUser(getSentryUser());
         }
         notifications.show({

--- a/src/components/Settings/PasskeyLogin.tsx
+++ b/src/components/Settings/PasskeyLogin.tsx
@@ -7,7 +7,7 @@ import { startAuthentication } from "@simplewebauthn/browser";
 import { navigate } from "vike/client/router";
 import { usePageContext } from "vike-react/usePageContext";
 import * as Sentry from "@sentry/react";
-import { getSentryUser, resolvePostLoginTarget } from "@/utils/session";
+import { getSentryUser, resolvePostLoginTarget, setAuthToken } from "@/utils/session";
 
 export const PasskeyLogin = () => {
   const [loading, setLoading] = useState(false);
@@ -45,7 +45,7 @@ export const PasskeyLogin = () => {
         return;
       }
 
-      localStorage.setItem("token", authData.data.token);
+      await setAuthToken(authData.data.token);
       Sentry.setUser(getSentryUser());
 
       const redirect = pageContext.urlParsed.search.redirect || pageContext.redirect;

--- a/src/components/Shell/Navbar/Navbar.tsx
+++ b/src/components/Shell/Navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Box, Container, Divider, ScrollArea } from "@mantine/core";
 import { NavbarButton } from "./NavbarButton";
-import { checkPermission, UserPermission } from "@/utils/session.ts";
+import { checkPermission, clearAuthSession, UserPermission } from "@/utils/session.ts";
 import { useLogoutUser } from "@/hooks/mutations/useUserMutations.ts";
 import {
   IconAward,
@@ -160,12 +160,11 @@ export default function Navbar({ style, onClose }: NavbarProps) {
             <NavbarButton
               label="登出"
               icon={<IconLogout stroke={1.5} />}
-              to="/"
               onClose={onClose}
               onClick={() => {
                 mutateLogout(undefined, {
-                  onSuccess: () => {
-                    localStorage.removeItem("token");
+                  onSettled: async () => {
+                    await clearAuthSession();
                     window.location.href = "/";
                   },
                 });

--- a/src/hooks/queries/queryKeys.ts
+++ b/src/hooks/queries/queryKeys.ts
@@ -3,7 +3,7 @@ import { Game } from "@/types/game";
 export const queryKeys = {
   user: {
     profile: () => ["user/profile"] as const,
-    refresh: () => ["user/refresh"] as const,
+    refresh: (identity: string | null) => ["user/refresh", identity] as const,
   },
   player: {
     root: (game: Game) => [`user/${game}/player`] as const,

--- a/src/hooks/queries/useUserToken.ts
+++ b/src/hooks/queries/useUserToken.ts
@@ -1,37 +1,38 @@
-import { useEffect } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getSentryUser, isTokenExpired, isTokenUndefined } from "@/utils/session.ts";
+import {
+  getAuthToken,
+  getSentryUser,
+  isTokenExpired,
+  subscribeAuthSession,
+} from "@/utils/session.ts";
 import * as Sentry from "@sentry/react";
 import { queryKeys } from "./queryKeys.ts";
+import { refreshAuthToken } from "@/utils/api/api.ts";
+import { getTokenSessionIdentity, isTokenSessionExpired } from "@/utils/sessionCore.ts";
 
 export const useUserToken = () => {
-  const shouldFetch = !isTokenUndefined();
+  const token = useSyncExternalStore(subscribeAuthSession, getAuthToken, () => null);
+  const identity = getTokenSessionIdentity(token);
+  const shouldRefresh = Boolean(token) && isTokenSessionExpired(token);
 
-  const { data, error, isLoading, refetch } = useQuery<{ token: string }>({
-    queryKey: queryKeys.user.refresh(),
-    enabled: shouldFetch,
+  const { error, isFetching, refetch } = useQuery({
+    queryKey: queryKeys.user.refresh(identity),
+    queryFn: async () => {
+      await refreshAuthToken();
+      return true;
+    },
+    enabled: shouldRefresh,
   });
 
   useEffect(() => {
-    if (data?.token) {
-      localStorage.setItem("token", data.token);
-      Sentry.setUser(getSentryUser());
-    }
-  }, [data?.token]);
-
-  if (!isTokenExpired()) {
-    return {
-      token: localStorage.getItem("token") || "",
-      isLoading: false,
-      error: null,
-      refetch: () => {},
-    };
-  }
+    if (token && !isTokenExpired()) Sentry.setUser(getSentryUser());
+  }, [token]);
 
   return {
-    token: data?.token || "",
-    isLoading,
-    error,
+    token: token || "",
+    isLoading: shouldRefresh && isFetching,
+    error: token && !shouldRefresh ? null : error,
     refetch,
   };
 };

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,6 +1,10 @@
 import { QueryClient } from "@tanstack/react-query";
 import { defaultQueryFn } from "@/hooks/queries/queryFn.ts";
 import { APIError } from "@/utils/errors.ts";
+import { registerAuthSessionChangeHandler } from "@/utils/session.ts";
+import useScoreStore from "@/hooks/useScoreStore.ts";
+import useCreateScoreStore from "@/hooks/useCreateScoreStore.ts";
+import useAliasStore from "@/hooks/useAliasStore.ts";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,4 +20,24 @@ export const queryClient = new QueryClient({
       staleTime: 30 * 1000,
     },
   },
+});
+
+const isUserScopedQuery = (query: { queryKey: readonly unknown[] }) => {
+  const endpoint = query.queryKey[0];
+  return typeof endpoint === "string" && (endpoint === "user" || endpoint.startsWith("user/"));
+};
+
+const resetUserScopedModalStores = () => {
+  useScoreStore.setState({ opened: false, score: null, onClose: undefined });
+  useCreateScoreStore.setState({ opened: false, score: null, onClose: undefined });
+  useAliasStore.setState({ opened: false, songId: null, onClose: undefined });
+};
+
+registerAuthSessionChangeHandler(async (phase) => {
+  if (phase === "cancel") {
+    await queryClient.cancelQueries({ predicate: isUserScopedQuery });
+  } else {
+    queryClient.removeQueries({ predicate: isUserScopedQuery });
+    resetUserScopedModalStores();
+  }
 });

--- a/src/pages/+Layout.tsx
+++ b/src/pages/+Layout.tsx
@@ -47,6 +47,7 @@ import classes from "@/App.module.css";
 import useGame from "@/hooks/useGame.ts";
 import { useThemeColor } from "@/hooks/useThemeColor.ts";
 import { NAVBAR_BREAKPOINT } from "@/components/Shell/Shell.tsx";
+import { isAuthenticationRefreshError } from "@/utils/api/api.ts";
 
 // Tag iOS so index.css can force inputs to >=16px and avoid Safari's focus-zoom.
 if (typeof document !== "undefined") {
@@ -128,7 +129,7 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
   const [game] = useGame();
 
   useEffect(() => {
-    if (userTokenError) {
+    if (userTokenError && isAuthenticationRefreshError(userTokenError)) {
       Sentry.setUser(null);
       logout();
 
@@ -141,7 +142,7 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
         });
       }
     }
-  }, [userTokenError]);
+  }, [pageContext.urlPathname, userTokenError]);
 
   useEffect(() => {
     if (viewport.current) {

--- a/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
+++ b/src/pages/admin/Panel/notifications/AdminNotificationsSection.tsx
@@ -14,9 +14,6 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconEdit, IconPlus, IconTrash } from "@tabler/icons-react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
 import dayjs from "dayjs";
 import { useAdminNotifications } from "@/hooks/queries/useAdminNotifications.ts";
 import { useDeleteNotification } from "@/hooks/mutations/useAdminNotificationMutations.ts";
@@ -26,6 +23,7 @@ import { NotificationTypeIcon } from "@/components/Notifications/NotificationTyp
 import { ResponsivePagination } from "@/components/ResponsivePagination.tsx";
 import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
 import { AdminBroadcast } from "@/types/notification";
+import { NotificationMarkdown } from "@/components/Notifications/NotificationMarkdown.tsx";
 
 const PAGE_SIZE = 10;
 
@@ -119,9 +117,7 @@ export function AdminNotificationsSection() {
             </Accordion.Control>
             <Accordion.Panel>
               <Typography>
-                <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-                  {b.content}
-                </Markdown>
+                <NotificationMarkdown content={b.content} />
               </Typography>
               <Group justify="flex-end" mt="sm" gap="xs">
                 <Tooltip label="编辑" position="top" withArrow>

--- a/src/pages/public/Login.tsx
+++ b/src/pages/public/Login.tsx
@@ -25,6 +25,7 @@ import {
   isTokenExpired,
   isTokenUndefined,
   resolvePostLoginTarget,
+  setAuthToken,
 } from "@/utils/session.ts";
 import * as Sentry from "@sentry/react";
 import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
@@ -111,7 +112,7 @@ export default function Login() {
         { values, captchaToken },
         {
           onSuccess: async (data) => {
-            localStorage.setItem("token", data.token);
+            await setAuthToken(data.token);
             Sentry.setUser(getSentryUser());
 
             const redirect = pageContext.urlParsed.search.redirect || pageContext.redirect;

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Title,
   Text,
@@ -51,60 +51,81 @@ function isAppSchemeRedirectUri(redirectUri: string | null): boolean {
 
 export default function Authorize() {
   const pageContext = usePageContext();
-  const params = new URLSearchParams(pageContext.urlParsed.search);
+  const searchOriginal = pageContext.urlParsed.searchOriginal ?? "";
+  const params = useMemo(() => new URLSearchParams(searchOriginal), [searchOriginal]);
   const { app, isLoading, error } = useOAuthApp(params);
-  const confirmOAuthAuthorize = useConfirmOAuthAuthorize();
+  const { mutateAsync: confirmOAuthAuthorize } = useConfirmOAuthAuthorize();
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [code, setCode] = useState("");
-  const requestedScopes = (params.get("scope") || "").split(" ").filter(Boolean);
+  const authorizingRef = useRef(false);
+  const autoAuthorizationStartedFor = useRef<string | null>(null);
+  const requestedScopes = useMemo(
+    () => (params.get("scope") || "").split(" ").filter(Boolean),
+    [params],
+  );
   const [selectedScopes, setSelectedScopes] = useState<string[]>(requestedScopes);
   // only ever offer/grant scopes the client is actually registered for — clients may over-request
   // (e.g. an MCP client reading the AS metadata picks up read_user_token, which is not an MCP scope)
-  const registeredScopes = (app?.scope ?? "").split(" ").filter(Boolean);
-  const allowedScopes = requestedScopes.filter((s) => registeredScopes.includes(s));
+  const registeredScopes = useMemo(
+    () => (app?.scope ?? "").split(" ").filter(Boolean),
+    [app?.scope],
+  );
+  const allowedScopes = useMemo(
+    () => requestedScopes.filter((scope) => registeredScopes.includes(scope)),
+    [registeredScopes, requestedScopes],
+  );
+
+  const handleAuthorize = useCallback(
+    async function authorize() {
+      if (!app || authorizingRef.current) return;
+      authorizingRef.current = true;
+      setIsAuthorizing(true);
+      try {
+        const resource = params.get("resource");
+        const data = await confirmOAuthAuthorize({
+          client_id: params.get("client_id") || "",
+          redirect_uri: params.get("redirect_uri") || "",
+          scope: app.is_dynamic
+            ? selectedScopes.filter((scope) => allowedScopes.includes(scope)).join(" ")
+            : allowedScopes.join(" "),
+          code_challenge: params.get("code_challenge") || "",
+          code_challenge_method: params.get("code_challenge_method") || "",
+          state: params.get("state") || "",
+          ...(resource ? { resource } : {}),
+        });
+        if (isOOBRedirectUri(app.redirect_uri)) {
+          setCode(data.code);
+        } else {
+          const redirect = new URL(app.redirect_uri);
+          redirect.searchParams.set("code", data.code);
+          if (data.state) {
+            redirect.searchParams.set("state", data.state);
+          }
+          window.location.href = redirect.toString();
+        }
+      } catch (error) {
+        openRetryModal("授权失败", `${error}`, authorize);
+      } finally {
+        authorizingRef.current = false;
+        setIsAuthorizing(false);
+      }
+    },
+    [allowedScopes, app, confirmOAuthAuthorize, params, selectedScopes],
+  );
 
   useEffect(() => {
-    if (!app) return;
-    if (!app.is_dynamic && app.user_authorized && !isOOBRedirectUri(app.redirect_uri)) {
-      setCode("authorized");
-      setTimeout(() => {
-        handleAuthorize();
-      }, 3000);
+    if (!app || app.is_dynamic || !app.user_authorized || isOOBRedirectUri(app.redirect_uri)) {
+      return;
     }
-  }, [app]);
 
-  const handleAuthorize = async () => {
-    if (!app) return;
-    setIsAuthorizing(true);
-    try {
-      const resource = params.get("resource");
-      const data = await confirmOAuthAuthorize.mutateAsync({
-        client_id: params.get("client_id") || "",
-        redirect_uri: params.get("redirect_uri") || "",
-        scope: app.is_dynamic
-          ? selectedScopes.filter((s) => allowedScopes.includes(s)).join(" ")
-          : allowedScopes.join(" "),
-        code_challenge: params.get("code_challenge") || "",
-        code_challenge_method: params.get("code_challenge_method") || "",
-        state: params.get("state") || "",
-        ...(resource ? { resource } : {}),
-      });
-      if (isOOBRedirectUri(app.redirect_uri)) {
-        setCode(data.code);
-      } else {
-        const redirect = new URL(app.redirect_uri);
-        redirect.searchParams.set("code", data.code);
-        if (data.state) {
-          redirect.searchParams.set("state", data.state);
-        }
-        window.location.href = redirect.toString();
-      }
-    } catch (error) {
-      openRetryModal("授权失败", `${error}`, handleAuthorize);
-    } finally {
-      setIsAuthorizing(false);
-    }
-  };
+    setCode("authorized");
+    const timeout = window.setTimeout(() => {
+      if (autoAuthorizationStartedFor.current === searchOriginal) return;
+      autoAuthorizationStartedFor.current = searchOriginal;
+      void handleAuthorize();
+    }, 3000);
+    return () => window.clearTimeout(timeout);
+  }, [app, handleAuthorize, searchOriginal]);
 
   const handleDeny = () => {
     if (!app) return;

--- a/src/pages/user/Settings/SecuritySettingsSection.tsx
+++ b/src/pages/user/Settings/SecuritySettingsSection.tsx
@@ -6,6 +6,7 @@ import { useDisclosure } from "@mantine/hooks";
 import classes from "../../Page.module.css";
 import { openConfirmModal, openRetryModal } from "@/utils/modal";
 import { deleteSelfUser } from "@/utils/api/user";
+import { clearAuthSession } from "@/utils/session.ts";
 
 export const SecuritySettingsSection = () => {
   const [editPasswordModalOpened, editPasswordModal] = useDisclosure(false);
@@ -17,7 +18,7 @@ export const SecuritySettingsSection = () => {
       if (!data.success) {
         throw new Error(data.message);
       }
-      localStorage.removeItem("token");
+      await clearAuthSession();
       window.location.href = "/";
     } catch (error) {
       openRetryModal("删除失败", `${error}`, deleteSelfUserHandler);

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -138,8 +138,16 @@ const createRequestHeaders = (headers?: Record<string, string>, token?: string |
   return requestHeaders;
 };
 
-const fetchApiRequest = ({ endpoint, init }: { endpoint: string; init: RequestInit }) =>
-  fetch(`${API_URL}/${endpoint}`, init);
+const API_ENDPOINT_ROOTS = new Set(["user", "maimai", "chunithm", "site"]);
+
+/** Rejects endpoints outside the API namespaces used by this client before issuing a request. */
+const fetchApiRequest = ({ endpoint, init }: { endpoint: string; init: RequestInit }) => {
+  const root = endpoint.split("/", 1)[0];
+  if (!API_ENDPOINT_ROOTS.has(root)) {
+    return Promise.reject(new TypeError("不支持的 API 端点"));
+  }
+  return fetch(`${API_URL}/${endpoint}`, init);
+};
 
 async function retryAfterUnauthorized(
   request: (token: string | null) => Promise<Response>,

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -143,10 +143,10 @@ const API_ENDPOINT_ROOTS = new Set(["user", "maimai", "chunithm", "site"]);
 /** Rejects endpoints outside the API namespaces used by this client before issuing a request. */
 const fetchApiRequest = ({ endpoint, init }: { endpoint: string; init: RequestInit }) => {
   const root = endpoint.split("/", 1)[0];
-  if (!API_ENDPOINT_ROOTS.has(root)) {
-    return Promise.reject(new TypeError("不支持的 API 端点"));
+  if (API_ENDPOINT_ROOTS.has(root)) {
+    return fetch(`${API_URL}/${endpoint}`, init);
   }
-  return fetch(`${API_URL}/${endpoint}`, init);
+  return Promise.reject(new TypeError("不支持的 API 端点"));
 };
 
 async function retryAfterUnauthorized(

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -138,6 +138,9 @@ const createRequestHeaders = (headers?: Record<string, string>, token?: string |
   return requestHeaders;
 };
 
+const fetchApiRequest = ({ endpoint, init }: { endpoint: string; init: RequestInit }) =>
+  fetch(`${API_URL}/${endpoint}`, init);
+
 async function retryAfterUnauthorized(
   request: (token: string | null) => Promise<Response>,
   requestToken: string,
@@ -171,11 +174,14 @@ export async function fetchAPI(
   const requestBody =
     body === undefined ? undefined : typeof body === "string" ? body : JSON.stringify(body);
   const request = (token: string | null) =>
-    fetch(`${API_URL}/${endpoint}`, {
-      method,
-      credentials: "include",
-      headers: createRequestHeaders(headers, token),
-      body: requestBody,
+    fetchApiRequest({
+      endpoint,
+      init: {
+        method,
+        credentials: "include",
+        headers: createRequestHeaders(headers, token),
+        body: requestBody,
+      },
     });
 
   if (auth === "none") return request(null);
@@ -204,11 +210,14 @@ export async function uploadFile(endpoint: string, file: File): Promise<Response
     const headers = new Headers();
     if (token) headers.set("Authorization", `Bearer ${token}`);
 
-    return fetch(`${API_URL}/${endpoint}`, {
-      method: "POST",
-      credentials: "include",
-      headers,
-      body: formData,
+    return fetchApiRequest({
+      endpoint,
+      init: {
+        method: "POST",
+        credentials: "include",
+        headers,
+        body: formData,
+      },
     });
   };
 

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -1,77 +1,218 @@
-import { isTokenExpired, isTokenUndefined } from "@/utils/session.ts";
-import { queryClient } from "@/lib/queryClient.ts";
+import {
+  clearAuthSessionForIdentity,
+  getAuthSessionIdentity,
+  getAuthToken,
+  isTokenExpired,
+  isTokenUndefined,
+  setRefreshedAuthToken,
+} from "@/utils/session.ts";
+import { APIError } from "@/utils/errors.ts";
+import { getTokenSessionIdentity } from "@/utils/sessionCore.ts";
 
 export const API_URL = import.meta.env.VITE_API_URL;
 
-let refreshPromise: Promise<void> | null = null;
+export class TokenRefreshError extends APIError {
+  authenticationFailure: boolean;
 
-async function refreshToken() {
+  constructor(
+    message: string,
+    options: { status?: number; code?: number; authenticationFailure?: boolean } = {},
+  ) {
+    super(message, options);
+    this.name = "TokenRefreshError";
+    this.authenticationFailure = options.authenticationFailure ?? false;
+  }
+}
+
+export const isAuthenticationRefreshError = (error: unknown) =>
+  error instanceof TokenRefreshError && error.authenticationFailure;
+
+const refreshPromises = new Map<string, Promise<{ token: string }>>();
+
+async function requestTokenRefresh(
+  currentToken: string,
+  expectedIdentity: string,
+): Promise<{ token: string }> {
   try {
     const response = await fetch(`${API_URL}/user/refresh`, {
       method: "GET",
       credentials: "include",
       headers: {
-        Authorization: `Bearer ${localStorage.getItem("token")}`,
+        Authorization: `Bearer ${currentToken}`,
         "Content-Type": "application/json",
       },
     });
 
-    if (response.ok) {
-      const data = await response.json();
-      localStorage.setItem("token", data.data.token);
-      queryClient.setQueryData(["user/refresh"], data.data);
-    } else {
-      // 刷新失败，清除过期 token，后续请求将由全局错误处理引导登录
-      localStorage.removeItem("token");
+    let data: {
+      success?: boolean;
+      message?: string;
+      code?: number;
+      data?: { token?: unknown };
+    };
+    const authenticationFailure = response.status === 401 || response.status === 403;
+    try {
+      data = await response.json();
+    } catch {
+      if (authenticationFailure) {
+        const cleared = await clearAuthSessionForIdentity(expectedIdentity);
+        if (!cleared) throw new TokenRefreshError("登录会话已变更，请重试");
+        throw new TokenRefreshError("登录会话已失效", {
+          status: response.status,
+          authenticationFailure: true,
+        });
+      }
+      throw new TokenRefreshError("服务器返回了无效的响应", { status: response.status });
     }
-  } finally {
-    refreshPromise = null;
+
+    if (authenticationFailure) {
+      const cleared = await clearAuthSessionForIdentity(expectedIdentity);
+      if (!cleared) throw new TokenRefreshError("登录会话已变更，请重试");
+      throw new TokenRefreshError(data.message || "登录会话已失效", {
+        status: response.status,
+        code: data.code,
+        authenticationFailure: true,
+      });
+    }
+
+    if (!response.ok || data.success === false) {
+      throw new TokenRefreshError(data.message || "刷新登录会话失败", {
+        status: response.status,
+        code: data.code,
+      });
+    }
+
+    if (typeof data.data?.token !== "string" || !data.data.token) {
+      throw new TokenRefreshError("服务器未返回有效的登录令牌", { status: response.status });
+    }
+
+    const stored = await setRefreshedAuthToken(data.data.token, expectedIdentity);
+    if (!stored) throw new TokenRefreshError("登录会话已变更，请重试");
+    return { token: data.data.token };
+  } catch (error) {
+    if (error instanceof TokenRefreshError) throw error;
+    throw new TokenRefreshError("暂时无法连接服务器以验证登录状态");
   }
+}
+
+/**
+ * Refreshes the current bearer token through the single shared in-flight request.
+ * Authentication failures clear the session; network and server failures preserve it for retry.
+ */
+export async function refreshAuthToken() {
+  const currentToken = getAuthToken();
+  const identity = getTokenSessionIdentity(currentToken);
+  if (!currentToken || !identity) {
+    throw new TokenRefreshError("登录会话不存在", {
+      status: 401,
+      authenticationFailure: true,
+    });
+  }
+
+  const inFlight = refreshPromises.get(identity);
+  if (inFlight) return inFlight;
+
+  const refresh = requestTokenRefresh(currentToken, identity).finally(() => {
+    if (refreshPromises.get(identity) === refresh) refreshPromises.delete(identity);
+  });
+  refreshPromises.set(identity, refresh);
+  return refresh;
 }
 
 async function ensureTokenValid() {
   if (!isTokenUndefined() && isTokenExpired()) {
-    if (!refreshPromise) {
-      refreshPromise = refreshToken();
-    }
-    await refreshPromise;
+    await refreshAuthToken();
   }
+}
+
+type RequestAuthMode = "required" | "optional" | "none";
+
+const getDefaultAuthMode = (endpoint: string): RequestAuthMode =>
+  endpoint === "user" || endpoint.startsWith("user/") ? "required" : "optional";
+
+const createRequestHeaders = (headers?: Record<string, string>, token?: string | null) => {
+  const requestHeaders = new Headers({
+    "Content-Type": "application/json",
+    ...headers,
+  });
+  if (token) requestHeaders.set("Authorization", `Bearer ${token}`);
+  return requestHeaders;
+};
+
+async function retryAfterUnauthorized(
+  request: (token: string | null) => Promise<Response>,
+  requestToken: string,
+) {
+  const requestIdentity = getTokenSessionIdentity(requestToken);
+  const response = await request(requestToken);
+  if (response.status !== 401 || !requestIdentity) return response;
+  if (getAuthSessionIdentity() !== requestIdentity) return response;
+
+  await refreshAuthToken();
+  const retryToken = getAuthToken();
+  if (getTokenSessionIdentity(retryToken) !== requestIdentity) return response;
+
+  const retriedResponse = await request(retryToken);
+  if (retriedResponse.status === 401) {
+    await clearAuthSessionForIdentity(requestIdentity);
+  }
+  return retriedResponse;
 }
 
 export async function fetchAPI(
   endpoint: string,
-  options: { method: string; body?: unknown; headers?: Record<string, string> },
+  options: {
+    method: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+    auth?: RequestAuthMode;
+  },
 ): Promise<Response> {
-  if (endpoint !== "user/refresh") {
-    await ensureTokenValid();
+  const { method = "GET", body, headers, auth = getDefaultAuthMode(endpoint) } = options;
+  const requestBody =
+    body === undefined ? undefined : typeof body === "string" ? body : JSON.stringify(body);
+  const request = (token: string | null) =>
+    fetch(`${API_URL}/${endpoint}`, {
+      method,
+      credentials: "include",
+      headers: createRequestHeaders(headers, token),
+      body: requestBody,
+    });
+
+  if (auth === "none") return request(null);
+
+  if (auth === "optional") {
+    const currentToken = getAuthToken();
+    const requestToken = currentToken && !isTokenExpired() ? currentToken : null;
+    const response = await request(requestToken);
+    return response.status === 401 && requestToken ? request(null) : response;
   }
 
-  const { method = "GET", body, headers } = options;
+  if (endpoint === "user/refresh") return request(getAuthToken());
 
-  return await fetch(`${API_URL}/${endpoint}`, {
-    method,
-    credentials: "include",
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-      "Content-Type": "application/json",
-      ...headers,
-    },
-    body: body ? (typeof body === "string" ? body : JSON.stringify(body)) : undefined,
-  });
+  await ensureTokenValid();
+  const requestToken = getAuthToken();
+  if (!requestToken) return request(null);
+  return retryAfterUnauthorized(request, requestToken);
 }
 
 export async function uploadFile(endpoint: string, file: File): Promise<Response> {
   await ensureTokenValid();
 
-  const formData = new FormData();
-  formData.append("file", file);
+  const request = (token: string | null) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const headers = new Headers();
+    if (token) headers.set("Authorization", `Bearer ${token}`);
 
-  return await fetch(`${API_URL}/${endpoint}`, {
-    method: "POST",
-    credentials: "include",
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-    },
-    body: formData,
-  });
+    return fetch(`${API_URL}/${endpoint}`, {
+      method: "POST",
+      credentials: "include",
+      headers,
+      body: formData,
+    });
+  };
+
+  const requestToken = getAuthToken();
+  if (!requestToken) return request(null);
+  return retryAfterUnauthorized(request, requestToken);
 }

--- a/src/utils/api/user.ts
+++ b/src/utils/api/user.ts
@@ -99,7 +99,7 @@ export async function deletePasskey(id: number): Promise<Response> {
 }
 
 export async function authenticatePasskey(data: PasskeyAuthenticateData): Promise<Response> {
-  return fetchAPI("user/passkey/authenticate", { method: "POST", body: data });
+  return fetchAPI("user/passkey/authenticate", { method: "POST", body: data, auth: "none" });
 }
 
 export async function getPasskeyRegisterChallenge(): Promise<Response> {
@@ -107,5 +107,5 @@ export async function getPasskeyRegisterChallenge(): Promise<Response> {
 }
 
 export async function getPasskeyLoginChallenge(): Promise<Response> {
-  return fetchAPI("user/passkey/challenge", { method: "GET" });
+  return fetchAPI("user/passkey/challenge", { method: "GET", auth: "none" });
 }

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,19 +1,119 @@
-import { logoutUser } from "./api/user.ts";
+import {
+  decodeLoginSessionPayload,
+  getTokenSessionIdentity,
+  isTokenSessionExpired,
+  parseStoredGame,
+  resolveSameOriginRedirect,
+  type SupportedGame,
+} from "./sessionCore.ts";
 
 const isBrowser = () => typeof window !== "undefined";
+type AuthSessionChangeHandler = (phase: "cancel" | "remove") => void | Promise<void>;
+
+let authSessionChangeHandler: AuthSessionChangeHandler | null = null;
+const authSessionListeners = new Set<() => void>();
+let authSessionUpdate: Promise<unknown> = Promise.resolve();
+
+export const getAuthToken = () => (isBrowser() ? localStorage.getItem("token") : null);
+export const getAuthSessionIdentity = () => getTokenSessionIdentity(getAuthToken());
+
+export const subscribeAuthSession = (listener: () => void) => {
+  authSessionListeners.add(listener);
+  return () => authSessionListeners.delete(listener);
+};
+
+export const registerAuthSessionChangeHandler = (handler: AuthSessionChangeHandler) => {
+  authSessionChangeHandler = handler;
+};
+
+const notifyAuthSessionListeners = () => {
+  for (const listener of authSessionListeners) listener();
+};
+
+const enqueueAuthSessionUpdate = <T>(update: () => Promise<T>): Promise<T> => {
+  const pendingUpdate = authSessionUpdate.then(update, update);
+  authSessionUpdate = pendingUpdate.catch(() => undefined);
+  return pendingUpdate;
+};
+
+const handleAuthStorageChange = (event: StorageEvent) => {
+  if (event.key !== "token" && event.key !== null) return;
+
+  void enqueueAuthSessionUpdate(async () => {
+    const identityChanged =
+      event.key === null ||
+      getTokenSessionIdentity(event.oldValue) !== getTokenSessionIdentity(event.newValue);
+    if (identityChanged) await authSessionChangeHandler?.("cancel");
+    if (identityChanged) await authSessionChangeHandler?.("remove");
+    notifyAuthSessionListeners();
+  });
+};
+
+if (isBrowser()) window.addEventListener("storage", handleAuthStorageChange);
+
+/**
+ * Stores a bearer token and clears cached user data before notifying account-switch subscribers.
+ */
+const storeAuthToken = (token: string, expectedIdentity?: string) =>
+  enqueueAuthSessionUpdate(async () => {
+    if (!isBrowser()) return false;
+
+    const previousToken = localStorage.getItem("token");
+    if (
+      expectedIdentity !== undefined &&
+      getTokenSessionIdentity(previousToken) !== expectedIdentity
+    ) {
+      return false;
+    }
+
+    const identityChanged =
+      getTokenSessionIdentity(previousToken) !== getTokenSessionIdentity(token);
+
+    if (identityChanged) await authSessionChangeHandler?.("cancel");
+
+    localStorage.setItem("token", token);
+    if (identityChanged) await authSessionChangeHandler?.("remove");
+    notifyAuthSessionListeners();
+    return true;
+  });
+
+export const setAuthToken = (token: string) => storeAuthToken(token);
+
+/** Stores a refreshed token only if the browser is still signed in to the originating account. */
+export const setRefreshedAuthToken = (token: string, expectedIdentity: string) =>
+  storeAuthToken(token, expectedIdentity);
+
+/**
+ * Removes the local bearer token and clears all cached data scoped to the signed-in user.
+ */
+const removeAuthToken = (expectedIdentity?: string) =>
+  enqueueAuthSessionUpdate(async () => {
+    if (!isBrowser()) return false;
+
+    const currentToken = localStorage.getItem("token");
+    if (
+      expectedIdentity !== undefined &&
+      getTokenSessionIdentity(currentToken) !== expectedIdentity
+    ) {
+      return false;
+    }
+
+    const hadToken = currentToken !== null;
+    if (hadToken) await authSessionChangeHandler?.("cancel");
+    localStorage.removeItem("token");
+    if (hadToken) await authSessionChangeHandler?.("remove");
+    notifyAuthSessionListeners();
+    return true;
+  });
+
+export const clearAuthSession = () => removeAuthToken();
+
+/** Clears a failed session only if no account switch occurred while the request was in flight. */
+export const clearAuthSessionForIdentity = (expectedIdentity: string) =>
+  removeAuthToken(expectedIdentity);
 
 const getLoginSessionPayload = () => {
-  if (!isBrowser()) return null;
-  const token = localStorage.getItem("token");
-  if (!token) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(atob(token.split(".")[1]));
-  } catch (error) {
-    return null;
-  }
+  return decodeLoginSessionPayload(getAuthToken());
 };
 
 export const getLoginUserId = () => {
@@ -32,41 +132,23 @@ export const getSentryUser = () => {
 };
 
 export const isTokenExpired = () => {
-  if (!isBrowser()) return true;
-  const token = localStorage.getItem("token");
-  if (!token) {
-    return true;
-  }
-
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    const currentTime = Date.now();
-    const expirationTime = payload.exp * 1000;
-
-    if (isNaN(expirationTime)) {
-      return true;
-    }
-
-    return currentTime > expirationTime;
-  } catch (error) {
-    return true;
-  }
+  return isTokenSessionExpired(getAuthToken());
 };
 
 export const isTokenUndefined = () => {
-  if (!isBrowser()) return true;
-  const token = localStorage.getItem("token");
-  return !token;
+  return !getAuthToken();
 };
 
 export const isTokenValid = () => {
   return !isTokenExpired();
 };
 
+/**
+ * Clears the local session without making a server request. Interactive logout should call the
+ * logout endpoint first, then clear locally even if that request fails.
+ */
 export const logout = () => {
-  if (!isBrowser()) return;
-  localStorage.removeItem("token");
-  logoutUser();
+  void clearAuthSession();
 };
 
 export enum UserPermission {
@@ -76,18 +158,8 @@ export enum UserPermission {
 }
 
 export const checkPermission = (permission: UserPermission) => {
-  if (!isBrowser()) return false;
-  const token = localStorage.getItem("token");
-  if (!token) {
-    return false;
-  }
-
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    return (payload.permission & permission) !== 0;
-  } catch (error) {
-    return false;
-  }
+  const payload = getLoginSessionPayload();
+  return typeof payload?.permission === "number" && (payload.permission & permission) !== 0;
 };
 
 export const permissionToList = (permission: number) => {
@@ -113,21 +185,15 @@ export const listToPermission = (list: UserPermission[]) => {
 };
 
 export const resolvePostLoginTarget = async (redirect?: string | null): Promise<string> => {
-  const EXCLUDED = ["/login", "/register"];
-  const redirectPathname = redirect?.split(/[?#]/)[0];
-  if (
-    redirect &&
-    redirect.startsWith("/") &&
-    !redirect.startsWith("//") &&
-    redirectPathname &&
-    !EXCLUDED.includes(redirectPathname)
-  ) {
-    return redirect;
-  }
+  const safeRedirect = resolveSameOriginRedirect(
+    redirect,
+    isBrowser() ? window.location.origin : "http://localhost",
+  );
+  if (safeRedirect) return safeRedirect;
 
   try {
-    const game = (isBrowser() && localStorage.getItem("game")) || "maimai";
-    const token = isBrowser() ? localStorage.getItem("token") : null;
+    const game = readStoredGame();
+    const token = getAuthToken();
     const apiUrl = import.meta.env.VITE_API_URL;
     const res = await fetch(`${apiUrl}/user/${game}/player`, {
       method: "GET",
@@ -137,13 +203,15 @@ export const resolvePostLoginTarget = async (redirect?: string | null): Promise<
       },
       credentials: "include",
     });
-    const data = await res.json();
-    if (data.success && data.data) {
-      return "/";
-    }
-  } catch {
-    // 网络错误时不阻断登录流程，直接跳首页
-  }
+    if (res.status === 404) return "/user/sync";
+    if (!res.ok) return "/";
 
-  return "/user/sync";
+    const data = (await res.json()) as { success?: boolean; data?: unknown };
+    return data.success && data.data ? "/" : "/user/sync";
+  } catch {
+    return "/";
+  }
 };
+
+export const readStoredGame = (fallback: SupportedGame = "maimai") =>
+  parseStoredGame(isBrowser() ? localStorage.getItem("game") : null, fallback);

--- a/src/utils/sessionCore.test.ts
+++ b/src/utils/sessionCore.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTokenSessionIdentity,
+  isTokenSessionExpired,
+  parseStoredGame,
+  resolveSameOriginRedirect,
+} from "./sessionCore.ts";
+
+const ORIGIN = "https://maimai.lxns.net";
+
+describe("resolveSameOriginRedirect", () => {
+  it("keeps safe same-origin paths", () => {
+    expect(resolveSameOriginRedirect("/user/scores?q=1#result", ORIGIN)).toBe(
+      "/user/scores?q=1#result",
+    );
+  });
+
+  it("rejects external and backslash redirects", () => {
+    expect(resolveSameOriginRedirect("//evil.example/path", ORIGIN)).toBeNull();
+    expect(resolveSameOriginRedirect("/\\evil.example/path", ORIGIN)).toBeNull();
+    expect(resolveSameOriginRedirect("/%5Cevil.example/path", ORIGIN)).toBeNull();
+    expect(resolveSameOriginRedirect("https://evil.example/path", ORIGIN)).toBeNull();
+  });
+
+  it("rejects authentication loop targets", () => {
+    expect(resolveSameOriginRedirect("/login?next=/", ORIGIN)).toBeNull();
+    expect(resolveSameOriginRedirect("/login/", ORIGIN)).toBeNull();
+    expect(resolveSameOriginRedirect("/register#form", ORIGIN)).toBeNull();
+  });
+});
+
+describe("parseStoredGame", () => {
+  it("accepts Mantine JSON and legacy storage values", () => {
+    expect(parseStoredGame('"maimai"')).toBe("maimai");
+    expect(parseStoredGame('"chunithm"')).toBe("chunithm");
+    expect(parseStoredGame("chunithm")).toBe("chunithm");
+    expect(parseStoredGame("invalid")).toBe("maimai");
+  });
+});
+
+describe("getTokenSessionIdentity", () => {
+  it("remains stable across refreshed tokens for the same user", () => {
+    const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const first = `${encode({ alg: "none" })}.${encode({ id: 42, exp: 1 })}.signature`;
+    const refreshed = `${encode({ alg: "none" })}.${encode({ id: 42, exp: 2 })}.signature`;
+    const anotherUser = `${encode({ alg: "none" })}.${encode({ id: 43, exp: 2 })}.signature`;
+
+    expect(getTokenSessionIdentity(first)).toBe(getTokenSessionIdentity(refreshed));
+    expect(getTokenSessionIdentity(first)).not.toBe(getTokenSessionIdentity(anotherUser));
+  });
+});
+
+describe("isTokenSessionExpired", () => {
+  it("evaluates the token snapshot against the supplied clock", () => {
+    const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const token = `${encode({ alg: "none" })}.${encode({ id: 42, exp: 2 })}.signature`;
+
+    expect(isTokenSessionExpired(token, 1000)).toBe(false);
+    expect(isTokenSessionExpired(token, 3000)).toBe(true);
+    expect(isTokenSessionExpired("malformed", 1000)).toBe(true);
+  });
+});

--- a/src/utils/sessionCore.ts
+++ b/src/utils/sessionCore.ts
@@ -1,0 +1,83 @@
+export type SupportedGame = "maimai" | "chunithm";
+
+const SUPPORTED_GAMES = new Set<SupportedGame>(["maimai", "chunithm"]);
+const EXCLUDED_REDIRECT_PATHS = new Set(["/login", "/register"]);
+
+export interface LoginSessionPayload {
+  id?: string | number;
+  sub?: string | number;
+  name?: string;
+  permission?: number;
+  exp?: number;
+}
+
+export function decodeLoginSessionPayload(token: string | null): LoginSessionPayload | null {
+  if (!token) return null;
+
+  const encodedPayload = token.split(".")[1];
+  if (!encodedPayload) return null;
+
+  try {
+    const normalizedPayload = encodedPayload.replace(/-/g, "+").replace(/_/g, "/");
+    const paddedPayload = normalizedPayload.padEnd(
+      normalizedPayload.length + ((4 - (normalizedPayload.length % 4)) % 4),
+      "=",
+    );
+    return JSON.parse(atob(paddedPayload)) as LoginSessionPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function getTokenSessionIdentity(token: string | null): string | null {
+  if (!token) return null;
+
+  const payload = decodeLoginSessionPayload(token);
+  const subject = payload?.sub ?? payload?.id;
+  return subject === undefined ? `token:${token}` : `user:${String(subject)}`;
+}
+
+export function isTokenSessionExpired(token: string | null, now = Date.now()): boolean {
+  const payload = decodeLoginSessionPayload(token);
+  return typeof payload?.exp !== "number" || now > payload.exp * 1000;
+}
+
+export function parseStoredGame(
+  storedValue: string | null,
+  fallback: SupportedGame = "maimai",
+): SupportedGame {
+  if (!storedValue) return fallback;
+
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(storedValue);
+  } catch {
+    candidate = storedValue;
+  }
+
+  return typeof candidate === "string" && SUPPORTED_GAMES.has(candidate as SupportedGame)
+    ? (candidate as SupportedGame)
+    : fallback;
+}
+
+export function resolveSameOriginRedirect(redirect: string | null | undefined, origin: string) {
+  if (!redirect || !redirect.startsWith("/")) return null;
+  const hasControlCharacter = Array.from(redirect).some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+  if (/\\|%5c/i.test(redirect) || hasControlCharacter) return null;
+
+  try {
+    const target = new URL(redirect, origin);
+    const isExcludedPath = Array.from(EXCLUDED_REDIRECT_PATHS).some(
+      (path) => target.pathname === path || target.pathname.startsWith(`${path}/`),
+    );
+    if (target.origin !== origin || isExcludedPath) {
+      return null;
+    }
+    return `${target.pathname}${target.search}${target.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/sessionCore.ts
+++ b/src/utils/sessionCore.ts
@@ -66,7 +66,8 @@ export function resolveSameOriginRedirect(redirect: string | null | undefined, o
     const code = character.charCodeAt(0);
     return code <= 31 || code === 127;
   });
-  if (/\\|%5c/i.test(redirect) || hasControlCharacter) return null;
+  const hasBackslash = redirect.includes("\\") || redirect.toLowerCase().includes("%5c");
+  if (hasBackslash || hasControlCharacter) return null;
 
   try {
     const target = new URL(redirect, origin);

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.9.2":
   version: 1.9.2
   resolution: "@emnapi/core@npm:1.9.2"
@@ -308,6 +318,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.2.1"
     tslib: "npm:^2.4.0"
   checksum: 10c0/5500393f953951bad0768fafaa9191f2d938956b20c6d6a79e5ab696a613a25ce6ad23422bc18e86e6ce8deb147619d8d0d7d413a69f84adc01a6633cc353cd9
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
   languageName: node
   linkType: hard
 
@@ -326,6 +345,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
   languageName: node
   linkType: hard
 
@@ -1042,6 +1070,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/344518bf3ef65051dda4c00969f293aa4a21ab7dc7822b3f48519b17cd5eaa3f0bc34898d115d50ba59b1817a0cb905d46f7a7223c8249239cd14c28db388e10
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -1102,6 +1142,13 @@ __metadata:
   version: 0.124.0
   resolution: "@oxc-project/types@npm:0.124.0"
   checksum: 10c0/9564ee3ce41f4b87802ffd0d62a7602d27f4503fbd39c1bedab98d54fde06e2ac254a8f85d8f679af1281a26e8fc7aa053fadbb3e09e786b38178eb38a8e2fb3
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.139.0":
+  version: 0.139.0
+  resolution: "@oxc-project/types@npm:0.139.0"
+  checksum: 10c0/ad57d1bee4b972ecf6784183da12ac6865edfff326bd83712fb75262b901868bc2b72d6fb502465a5f0dbaaded2910003f73365caf3821901dad565cc0b7fdf2
   languageName: node
   linkType: hard
 
@@ -1288,9 +1335,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-android-arm64@npm:1.1.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.15"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.1.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -1302,9 +1363,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-x64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-darwin-x64@npm:1.1.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.15"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.1.5"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1316,9 +1391,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.1.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.15"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.5"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -1330,9 +1419,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-musl@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.1.5"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.15"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.5"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -1344,9 +1447,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-s390x-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.15"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.5"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -1358,9 +1475,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.1.5"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.15"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.5"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -1376,6 +1507,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-wasm32-wasi@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.1.5"
+  dependencies:
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.15"
@@ -1383,9 +1525,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-arm64-msvc@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.15"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1401,6 +1557,13 @@ __metadata:
   version: 1.0.0-rc.7
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.7"
   checksum: 10c0/9d5490b5805b25bcd1720ca01c4c032b55a0ef953dab36a8dd42c568e82214576baa464f3027cd5dff3fabcfbe3bf3db2251d12b60220f5d1cd2ffde5ee37082
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -2125,6 +2288,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
+  languageName: node
+  linkType: hard
+
 "@types/d3-array@npm:^3.0.3":
   version: 3.2.2
   resolution: "@types/d3-array@npm:3.2.2"
@@ -2200,6 +2382,13 @@ __metadata:
   dependencies:
     "@types/ms": "npm:*"
   checksum: 10c0/e5e124021bbdb23a82727eee0a726ae0fc8a3ae1f57253cbcc47497f259afb357de7f6941375e773e1abbfa1604c1555b901a409d762ec2bb4c1612131d4afb7
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
   languageName: node
   linkType: hard
 
@@ -2742,6 +2931,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a817ad0d9bd6a039776a7228d54fb8319c17e4af15917407f5566ac61781a8511f591d302519d6999217399915bc3c0290028189fc73f5c38f80cb01b6f19c8d
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
+  dependencies:
+    "@vitest/spy": "npm:4.1.10"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/4aa70b0df58681652e2e28093437fb2e8f4d02a6d03f5619abc266ac1c5ae5f43326148061d13ae6e071e0f6cfcf7634659af63644de8ce098a7c98949a3d1ad
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/1a5daba730ffe23f2000bff484b4b2842f3b178d93663cb487b215516b8d3b62caa3e2bb2a3c63307b61a9fe58fb9bfff38559bc0c5e49d8aa403d6803a1d918
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
+  dependencies:
+    "@vitest/utils": "npm:4.1.10"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/554b72639de9694271b99be8ae273fe12ec793093ec91cce143816cd1187d40b7138a4d9d4de4f456cfca9567de986825bff97e107c05b9eb4abc130e854286d
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e71398725f51af5fd0c07bb4b957d0f987daf9b4c564ac24cb2a4d1afde1a6939f535ac17761a32dcc41b0a1e6d4088af66dc44df89fdebebb92aabed1a92b5f
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10c0/e5c08012560af6727fd66741c5cda25560d7c5442103d0c83e4276a9b0dd90b9da6cdf823a461195229a16c6ff87768ce788a68d0fa29dea73ee285618668178
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/05b0ecec6997ec22fc08377e57dbd8fa37992e05961f3a7a916d98b1ab56d15c2a87dbd83d392b628242bdc156b1705e7fa60a3bf0c54bdb51158c153e05fc5d
+  languageName: node
+  linkType: hard
+
 "@xobotyi/scrollbar-width@npm:^1.9.5":
   version: 1.9.5
   resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
@@ -2881,6 +3152,13 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -3156,6 +3434,13 @@ __metadata:
   dependencies:
     follow-redirects: "npm:^1.15.6"
   checksum: 10c0/ff0184fb3a8c72532550065dfee15f64ce619517e9e1323f2f2cf31333bd3b5f0b3fa1f10be51c26f43a83ed49b1d6c660d4c793a1e8b896ba1e288f766b7c35
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -3706,6 +3991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10c0/ada8b222772b5b8ea92eb6054c383233207418621855a07b480fdd36979b658a41414be09e793fcdd8a67a182741475f47830a01ff2ebd4353d7f6965c7c45f9
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -3963,6 +4255,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -3995,6 +4296,13 @@ __metadata:
   version: 0.1.12
   resolution: "exif-parser@npm:0.1.12"
   checksum: 10c0/ef1df84edbba50621fcfe19510c8db3ddd9e7fb374459d3f77c9256c24584767c7fb4cf1b15aef46e87a06528d3c48e44de02cecc314656d22a5cf954a0e7192
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -4616,6 +4924,17 @@ __metadata:
     web-namespaces: "npm:^2.0.0"
     zwitch: "npm:^2.0.0"
   checksum: 10c0/d0d909d2aedecef6a06f0005cfae410d6475e6e182d768bde30c3af9fcbbe4f9beb0522bdc21d0679cb3c243c0df40385797ed255148d68b3d3f12e82d12aacc
+  languageName: node
+  linkType: hard
+
+"hast-util-sanitize@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "hast-util-sanitize@npm:5.0.2"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    unist-util-position: "npm:^5.0.0"
+  checksum: 10c0/20951652078a8c21341c1c9a84f90015b2ba01cc41fa16772f122c65cda26a7adb0501fdeba5c8e37e40e2632447e8fe455d0dd2dc27d39663baacca76f2ecb6
   languageName: node
   linkType: hard
 
@@ -5527,6 +5846,7 @@ __metadata:
     recharts: "npm:3.8.1"
     rehype-autolink-headings: "npm:7.1.0"
     rehype-raw: "npm:7.0.0"
+    rehype-sanitize: "npm:^6.0.0"
     rehype-slug: "npm:6.0.0"
     remark: "npm:15.0.1"
     remark-flexible-containers: "npm:1.5.3"
@@ -5542,6 +5862,7 @@ __metadata:
     vike: "npm:0.4.257"
     vike-react: "npm:0.6.21"
     vite: "npm:8.0.8"
+    vitest: "npm:^4.1.10"
     wanakana: "npm:5.3.1"
     wordcloud: "npm:1.2.3"
     zustand: "npm:4.5.7"
@@ -6430,6 +6751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.12":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -6544,6 +6874,13 @@ __metadata:
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
+  languageName: node
+  linkType: hard
+
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
   languageName: node
   linkType: hard
 
@@ -6842,6 +7179,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "peek-readable@npm:^4.1.0":
   version: 4.1.0
   resolution: "peek-readable@npm:4.1.0"
@@ -6876,6 +7220,13 @@ __metadata:
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
   languageName: node
   linkType: hard
 
@@ -7053,6 +7404,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.17":
+  version: 8.5.19
+  resolution: "postcss@npm:8.5.19"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/302af9e4dfa8cce4f43af1798576b3a77ab7b23abac5522328c6c7a830d49b31281cba9d6071e478e6970a05ef82346d1570b8fbffae912f26a4f1a1a07f0a44
   languageName: node
   linkType: hard
 
@@ -7739,6 +8101,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rehype-sanitize@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "rehype-sanitize@npm:6.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-sanitize: "npm:^5.0.0"
+  checksum: 10c0/43d6c056e63c994cf56e5ee0e157052d2030dc5ac160845ee494af9a26e5906bf5ec5af56c7d90c99f9c4dc0091e45a48a168618135fb6c64a76481ad3c449e9
+  languageName: node
+  linkType: hard
+
 "rehype-slug@npm:6.0.0":
   version: 6.0.0
   resolution: "rehype-slug@npm:6.0.0"
@@ -7964,6 +8336,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.1.5":
+  version: 1.1.5
+  resolution: "rolldown@npm:1.1.5"
+  dependencies:
+    "@oxc-project/types": "npm:=0.139.0"
+    "@rolldown/binding-android-arm64": "npm:1.1.5"
+    "@rolldown/binding-darwin-arm64": "npm:1.1.5"
+    "@rolldown/binding-darwin-x64": "npm:1.1.5"
+    "@rolldown/binding-freebsd-x64": "npm:1.1.5"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.1.5"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.1.5"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-x64-musl": "npm:1.1.5"
+    "@rolldown/binding-openharmony-arm64": "npm:1.1.5"
+    "@rolldown/binding-wasm32-wasi": "npm:1.1.5"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.1.5"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.1.5"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/93072aa9d95882f9fa5cd57fe7db6a48efd6f85a25a32137425052ecca02df653651eed0c33a865c33511681bd6a40691d5c88900b8e95ce1334f4f75ba826ff
+  languageName: node
+  linkType: hard
+
 "rope-sequence@npm:^1.3.0":
   version: 1.3.4
   resolution: "rope-sequence@npm:1.3.4"
@@ -8143,6 +8573,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.0.1":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -8272,6 +8709,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -8297,6 +8741,13 @@ __metadata:
     stack-generator: "npm:^2.0.5"
     stacktrace-gps: "npm:^3.0.4"
   checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10c0/40ac525ce7b7c556abc332a7376f14356eeb1a7f17f6ff9a003eb9f52326ff1f3745d3e1b43452675b1ec6fcc319f1b1d6f3b0d386cf3f91058479ad883cff69
   languageName: node
   linkType: hard
 
@@ -8633,10 +9084,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.4.1":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 10c0/9aa79a36ba2c2a87cb221453465cabacd04b9e35f9694373e846fdc78b1c768110f81e581ea41440106c0f24d9a023891d0887e8075885e790ac40eb0e74a5c1
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.2.4
+  resolution: "tinyexec@npm:1.2.4"
+  checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
   languageName: node
   linkType: hard
 
@@ -8650,10 +9115,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
 "tinypool@npm:2.1.0":
   version: 2.1.0
   resolution: "tinypool@npm:2.1.0"
   checksum: 10c0/9fb1c760558c6264e0f4cfde96a63b12450b43f1730fbe6274aa24ddbdf488745c08924d0dea7a1303b47d555416a6415f2113898c69b6ecf731e75ac95238a5
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -9271,6 +9753,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.1.5
+  resolution: "vite@npm:8.1.5"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.17"
+    rolldown: "npm:~1.1.5"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.3.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/3231e24dd4394d0bc8b4f0f5d6d6a2eda8737e5053042892b4163564456a03d67f953c4c7498621f9517eebc30a492ea136c728a767a122eb84bf6d7cf60e1e6
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
+  dependencies:
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10c0/ff07294a57f9c62f3b503f7cf88a52ee0753ed26389a49cda430387a3898f39d80af47180b0af19e27acab5bd11ae95706bd4b44ce8befc97d3ae49af6ca4fc1
+  languageName: node
+  linkType: hard
+
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
@@ -9353,6 +9960,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 改动说明

修复认证刷新、账号切换和授权流程中的竞态与缓存残留问题，同时对通知 Markdown 内容进行安全清洗。

## 主要改动

- 统一 Token 写入、刷新和会话清理流程，避免并发刷新覆盖新会话。
- 在账号切换和登出时清理用户查询缓存，防止跨账号数据残留。
- 加固通行密钥登录、密码修改和认证请求的错误处理。
- 防止 OAuth 自动授权和手动提交重复执行。
- 使用 Markdown sanitizer 过滤通知内容，并补充会话与通知模板测试。

## 验证

- `yarn install --immutable`
- `yarn tsc --noEmit`
- `yarn test`：2 个测试文件、8 个测试通过
- `yarn build`
- 变更文件 ESLint 错误检查通过；主分支既有 warnings 未在本 PR 中扩展处理

## 合并说明

该 PR 直接基于 `main`，可与其余审计 PR 按任意顺序独立合并。新增 `rehype-sanitize`、Vitest 配置及 `test` 脚本；CI 与 Sentry 配置未修改。
