### PR TITLE
feat: add OIDC scopes to OAuth client UX

### DIFF
--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -7,10 +7,12 @@ import {
   Box,
   Button,
   Checkbox,
+  Fieldset,
   Group,
   HoverCard,
   Modal,
   SimpleGrid,
+  Stack,
   Switch,
   TagsInput,
   Text,
@@ -29,7 +31,7 @@ import {
 import { IconAlertCircle, IconHelp } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 import { OAuthAppProps } from "@/types/developer";
-import { scopeData } from "@/data/scopeData.tsx";
+import { scopeData, scopeGroups } from "@/data/scopeData.tsx";
 
 interface FormValues {
   name: string;
@@ -179,6 +181,7 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
       onClose={onClose}
       onExitTransitionEnd={form.reset}
       title={!app ? "创建 OAuth 应用" : "编辑 OAuth 应用"}
+      size="lg"
       centered
     >
       <form
@@ -278,18 +281,41 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
             );
           }}
         >
-          <SimpleGrid type="container" cols={{ base: 1, "350px": 2 }} spacing="xs" mt="xs">
-            {Object.entries(scopeData).map(([key, value]) => (
-              <Switch
-                key={key}
-                value={key}
-                label={value.title}
-                disabled={
-                  (key === "profile" || key === "email") && !form.values.scopes?.includes("openid")
+          <Stack gap="sm" mt="xs">
+            {scopeGroups.map((group) => (
+              <Fieldset
+                key={group.key}
+                variant="filled"
+                radius="md"
+                legend={
+                  <Text size="sm" fw={500}>
+                    {group.title}{" "}
+                    <Text component="span" inherit c="dimmed" fw={400}>
+                      · {group.protocol}
+                    </Text>
+                  </Text>
                 }
-              />
+              >
+                <Text size="xs" c="dimmed" mb="sm">
+                  {group.description}
+                </Text>
+                <SimpleGrid type="container" cols={{ base: 1, "440px": 2 }} spacing="xs">
+                  {group.scopes.map((key) => (
+                    <Switch
+                      key={key}
+                      value={key}
+                      label={scopeData[key].title}
+                      description={scopeData[key].description}
+                      disabled={
+                        (key === "profile" || key === "email") &&
+                        !form.values.scopes?.includes("openid")
+                      }
+                    />
+                  ))}
+                </SimpleGrid>
+              </Fieldset>
             ))}
-          </SimpleGrid>
+          </Stack>
         </Switch.Group>
         {form.values.scopes?.includes("read_user_token") && (
           <Alert variant="light" color="yellow" icon={<IconAlertCircle />} title="注意" mt="lg">

--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -316,7 +316,6 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
                           key={key}
                           value={key}
                           label={scopeData[key].title}
-                          description={scopeData[key].description}
                           disabled={
                             (key === "profile" || key === "email") &&
                             !form.values.scopes?.includes("openid")

--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   SimpleGrid,
   Switch,
+  TagsInput,
   Text,
   Textarea,
   TextInput,
@@ -35,7 +36,7 @@ interface FormValues {
   description: string;
   website: string;
   logo_url?: string;
-  redirect_uri: string;
+  redirect_uris: string[];
   scope?: string;
   scopes?: string[];
 }
@@ -46,6 +47,9 @@ interface CreateOAuthClientModalProps {
   onClose(): void;
 }
 
+const MAX_REDIRECT_URIS = 10;
+const MAX_REDIRECT_URI_LENGTH = 2048;
+
 export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClientModalProps) => {
   const [oobChecked, setOobChecked] = useState(false);
   const form = useForm<FormValues>({
@@ -53,7 +57,7 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
       name: "",
       description: "",
       website: "",
-      redirect_uri: "",
+      redirect_uris: [],
       scopes: [],
     },
 
@@ -67,7 +71,18 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
         }),
       description: (value) => validateText(value, { allowEmpty: true, textLabel: "应用描述" }),
       website: (value) => validateUrl(value, { allowEmpty: true, urlLabel: "应用网站" }),
-      redirect_uri: (value) => validateRedirectUri(value),
+      redirect_uris: (values) => {
+        if (values.length === 0) return "至少添加一个回调地址";
+        if (values.length > MAX_REDIRECT_URIS) return `最多添加 ${MAX_REDIRECT_URIS} 个回调地址`;
+        for (const value of values) {
+          if (value.length > MAX_REDIRECT_URI_LENGTH)
+            return `单个回调地址不能超过 ${MAX_REDIRECT_URI_LENGTH} 个字符`;
+          const error = validateRedirectUri(value);
+          if (error) return error;
+        }
+        if (new Set(values).size !== values.length) return "回调地址不能重复";
+        return null;
+      },
       scopes: (value) => {
         if (!value || value.length === 0) return "至少选择一个权限范围";
         return null;
@@ -79,7 +94,7 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
       description: values.description,
       website: values.website,
       logo_url: values.logo_url || "",
-      redirect_uri: values.redirect_uri,
+      redirect_uris: values.redirect_uris,
       scope: values.scopes?.join(" ") || "",
     }),
   });
@@ -141,9 +156,14 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
       form.setFieldValue("description", app.description || "");
       form.setFieldValue("website", app.website || "");
       form.setFieldValue("logo_url", app.logo_url || "");
-      form.setFieldValue("redirect_uri", app.redirect_uri || "");
+      const redirectUris = app.redirect_uris?.length
+        ? app.redirect_uris
+        : app.redirect_uri
+          ? [app.redirect_uri]
+          : [];
+      form.setFieldValue("redirect_uris", redirectUris);
       form.setFieldValue("scopes", app.scope ? app.scope.split(" ") : []);
-      setOobChecked(app.redirect_uri === "urn:ietf:wg:oauth:2.0:oob");
+      setOobChecked(redirectUris.length === 1 && redirectUris[0] === "urn:ietf:wg:oauth:2.0:oob");
     } else {
       form.reset();
       setOobChecked(false);
@@ -204,13 +224,17 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
           mb="xs"
           {...form.getInputProps("description")}
         />
-        <TextInput
+        <TagsInput
           label="回调地址"
-          description="OAuth 授权成功后，用户将被重定向到此地址"
+          description="OAuth 授权成功后，用户将被重定向到请求中指定的已注册地址"
           placeholder="https://example.com/callback"
           mb="xs"
           withAsterisk
-          {...form.getInputProps("redirect_uri")}
+          disabled={oobChecked}
+          maxTags={MAX_REDIRECT_URIS}
+          splitChars={[",", " "]}
+          clearable
+          {...form.getInputProps("redirect_uris")}
         />
         <Group gap="xs" align="center" mb="xs">
           <Checkbox
@@ -219,8 +243,8 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
             onChange={(event) => {
               setOobChecked(event.currentTarget.checked);
               form.setFieldValue(
-                "redirect_uri",
-                event.currentTarget.checked ? "urn:ietf:wg:oauth:2.0:oob" : "",
+                "redirect_uris",
+                event.currentTarget.checked ? ["urn:ietf:wg:oauth:2.0:oob"] : [],
               );
             }}
           />

--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -2,17 +2,17 @@ import { useForm } from "@mantine/form";
 import { validateText, validateUrl, validateRedirectUri } from "@/utils/validator.ts";
 import { openAlertModal, openRetryModal } from "@/utils/modal.tsx";
 import {
+  Accordion,
   Alert,
   Avatar,
+  Badge,
   Box,
   Button,
   Checkbox,
-  Fieldset,
   Group,
   HoverCard,
   Modal,
   SimpleGrid,
-  Stack,
   Switch,
   TagsInput,
   Text,
@@ -281,41 +281,54 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
             );
           }}
         >
-          <Stack gap="sm" mt="xs">
-            {scopeGroups.map((group) => (
-              <Fieldset
-                key={group.key}
-                variant="filled"
-                radius="md"
-                legend={
-                  <Text size="sm" fw={500}>
-                    {group.title}{" "}
-                    <Text component="span" inherit c="dimmed" fw={400}>
-                      · {group.protocol}
-                    </Text>
-                  </Text>
-                }
-              >
-                <Text size="xs" c="dimmed" mb="sm">
-                  {group.description}
-                </Text>
-                <SimpleGrid type="container" cols={{ base: 1, "440px": 2 }} spacing="xs">
-                  {group.scopes.map((key) => (
-                    <Switch
-                      key={key}
-                      value={key}
-                      label={scopeData[key].title}
-                      description={scopeData[key].description}
-                      disabled={
-                        (key === "profile" || key === "email") &&
-                        !form.values.scopes?.includes("openid")
-                      }
-                    />
-                  ))}
-                </SimpleGrid>
-              </Fieldset>
-            ))}
-          </Stack>
+          <Accordion multiple variant="contained" mt="xs">
+            {scopeGroups.map((group) => {
+              const selectedCount = group.scopes.filter((scope) =>
+                form.values.scopes?.includes(scope),
+              ).length;
+
+              return (
+                <Accordion.Item key={group.key} value={group.key}>
+                  <Accordion.Control>
+                    <Group justify="space-between" wrap="nowrap" pr="xs">
+                      <Box>
+                        <Text size="sm" fw={500}>
+                          {group.title}{" "}
+                          <Text component="span" inherit c="dimmed" fw={400}>
+                            · {group.protocol}
+                          </Text>
+                        </Text>
+                        <Text size="xs" c="dimmed" mt={2}>
+                          {group.description}
+                        </Text>
+                      </Box>
+                      {selectedCount > 0 && (
+                        <Badge variant="light" size="sm" style={{ flexShrink: 0 }}>
+                          已选 {selectedCount}
+                        </Badge>
+                      )}
+                    </Group>
+                  </Accordion.Control>
+                  <Accordion.Panel>
+                    <SimpleGrid type="container" cols={{ base: 1, "440px": 2 }} spacing="sm">
+                      {group.scopes.map((key) => (
+                        <Switch
+                          key={key}
+                          value={key}
+                          label={scopeData[key].title}
+                          description={scopeData[key].description}
+                          disabled={
+                            (key === "profile" || key === "email") &&
+                            !form.values.scopes?.includes("openid")
+                          }
+                        />
+                      ))}
+                    </SimpleGrid>
+                  </Accordion.Panel>
+                </Accordion.Item>
+              );
+            })}
+          </Accordion>
         </Switch.Group>
         {form.values.scopes?.includes("read_user_token") && (
           <Alert variant="light" color="yellow" icon={<IconAlertCircle />} title="注意" mt="lg">

--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -232,7 +232,7 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
         />
         <TagsInput
           label="回调地址"
-          description="OAuth 授权成功后，用户将被重定向到请求中指定的已注册地址"
+          description="授权成功后跳转到请求指定的地址；仅有一个地址时可省略"
           placeholder="https://example.com/callback"
           mb="xs"
           withAsterisk

--- a/src/components/Developer/CreateOAuthClientModal.tsx
+++ b/src/components/Developer/CreateOAuthClientModal.tsx
@@ -85,6 +85,9 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
       },
       scopes: (value) => {
         if (!value || value.length === 0) return "至少选择一个权限范围";
+        if ((value.includes("profile") || value.includes("email")) && !value.includes("openid")) {
+          return "用户资料和邮箱权限需要同时选择验证用户身份";
+        }
         return null;
       },
     },
@@ -266,10 +269,25 @@ export const CreateOAuthClientModal = ({ app, opened, onClose }: CreateOAuthClie
           description="选择应用需要的权限范围，用户在授权时会看到这些权限"
           withAsterisk
           {...form.getInputProps("scopes")}
+          onChange={(scopes) => {
+            form.setFieldValue(
+              "scopes",
+              scopes.includes("openid")
+                ? scopes
+                : scopes.filter((scope) => scope !== "profile" && scope !== "email"),
+            );
+          }}
         >
           <SimpleGrid type="container" cols={{ base: 1, "350px": 2 }} spacing="xs" mt="xs">
             {Object.entries(scopeData).map(([key, value]) => (
-              <Switch key={key} value={key} label={value.title} />
+              <Switch
+                key={key}
+                value={key}
+                label={value.title}
+                disabled={
+                  (key === "profile" || key === "email") && !form.values.scopes?.includes("openid")
+                }
+              />
             ))}
           </SimpleGrid>
         </Switch.Group>

--- a/src/components/Developer/DeveloperOAuthSection.tsx
+++ b/src/components/Developer/DeveloperOAuthSection.tsx
@@ -98,7 +98,7 @@ const OAuthAppCard = ({
             <Group gap={4} wrap="nowrap" style={{ minWidth: 0 }}>
               <IconLink size={12} style={{ color: "var(--mantine-color-dimmed)", flexShrink: 0 }} />
               <Text size="xs" c="dimmed" truncate>
-                {redirectUris[0]}
+                {redirectUris[0] || "未配置回调地址"}
                 {redirectUris.length > 1 && `（另有 ${redirectUris.length - 1} 个）`}
               </Text>
             </Group>

--- a/src/components/Developer/DeveloperOAuthSection.tsx
+++ b/src/components/Developer/DeveloperOAuthSection.tsx
@@ -11,6 +11,7 @@ import {
   Grid,
   Group,
   Loader,
+  Select,
   Stack,
   Text,
   TextInput,
@@ -39,6 +40,9 @@ import classes from "./DeveloperOAuthSection.module.css";
 
 const MAX_APPS = 5;
 
+const getRedirectUris = (app: OAuthAppProps): string[] =>
+  app.redirect_uris?.length ? app.redirect_uris : app.redirect_uri ? [app.redirect_uri] : [];
+
 const TextInputWithCopyButton = ({ label, value }: { label: string; value: string }) => (
   <TextInput
     label={label}
@@ -61,16 +65,23 @@ const TextInputWithCopyButton = ({ label, value }: { label: string; value: strin
 
 const OAuthAppCard = ({
   app,
-  authLink,
+  authLinks,
   onEdit,
   onDelete,
 }: {
   app: OAuthAppProps;
-  authLink: string;
+  authLinks: { redirectUri: string; value: string }[];
   onEdit: () => void;
   onDelete: () => void;
 }) => {
   const [expanded, setExpanded] = useState(false);
+  const redirectUris = getRedirectUris(app);
+  const [selectedRedirectUri, setSelectedRedirectUri] = useState(redirectUris[0] ?? "");
+  const activeRedirectUri = redirectUris.includes(selectedRedirectUri)
+    ? selectedRedirectUri
+    : (redirectUris[0] ?? "");
+  const activeAuthLink =
+    authLinks.find((authLink) => authLink.redirectUri === activeRedirectUri)?.value ?? "";
 
   return (
     <Card className={classes.appCard} withBorder radius="md" p={0}>
@@ -87,7 +98,8 @@ const OAuthAppCard = ({
             <Group gap={4} wrap="nowrap" style={{ minWidth: 0 }}>
               <IconLink size={12} style={{ color: "var(--mantine-color-dimmed)", flexShrink: 0 }} />
               <Text size="xs" c="dimmed" truncate>
-                {app.redirect_uri}
+                {redirectUris[0]}
+                {redirectUris.length > 1 && `（另有 ${redirectUris.length - 1} 个）`}
               </Text>
             </Group>
             {app.create_time && (
@@ -139,8 +151,24 @@ const OAuthAppCard = ({
             <Grid.Col span={{ base: 12, sm: 6 }}>
               <TextInputWithCopyButton label="应用密钥" value={app.client_secret || ""} />
             </Grid.Col>
+            {redirectUris.length > 1 && (
+              <Grid.Col span={12}>
+                <Select
+                  label="回调地址"
+                  variant="filled"
+                  data={redirectUris}
+                  value={activeRedirectUri}
+                  onChange={(value) => setSelectedRedirectUri(value ?? activeRedirectUri)}
+                  allowDeselect={false}
+                  searchable
+                  comboboxProps={{
+                    transitionProps: { transition: "fade", duration: 100, timingFunction: "ease" },
+                  }}
+                />
+              </Grid.Col>
+            )}
             <Grid.Col span={12}>
-              <TextInputWithCopyButton label="OAuth 授权链接" value={authLink} />
+              <TextInputWithCopyButton label="OAuth 授权链接" value={activeAuthLink} />
             </Grid.Col>
           </Grid>
         </Collapse>
@@ -156,14 +184,19 @@ export const DeveloperOAuthSection = () => {
   const [opened, modal] = useDisclosure(false);
   const [selectedApp, setSelectedApp] = useState<OAuthAppProps | null>(null);
 
-  const generateOAuthAppLink = (app: OAuthAppProps) => {
-    const params = new URLSearchParams({
-      response_type: "code",
-      client_id: app.client_id || "",
-      redirect_uri: app.redirect_uri,
-      scope: Array.isArray(app.scope) ? app.scope.join(" ") : app.scope,
+  const generateOAuthAppLinks = (app: OAuthAppProps) => {
+    return getRedirectUris(app).map((redirectUri) => {
+      const params = new URLSearchParams({
+        response_type: "code",
+        client_id: app.client_id || "",
+        redirect_uri: redirectUri,
+        scope: Array.isArray(app.scope) ? app.scope.join(" ") : app.scope,
+      });
+      return {
+        redirectUri,
+        value: `${window.location.origin}/oauth/authorize?${params.toString()}`,
+      };
     });
-    return `${window.location.origin}/oauth/authorize?${params.toString()}`;
   };
 
   const openCreate = () => {
@@ -222,7 +255,7 @@ export const DeveloperOAuthSection = () => {
               <OAuthAppCard
                 key={app.client_id || app.name}
                 app={app}
-                authLink={generateOAuthAppLink(app)}
+                authLinks={generateOAuthAppLinks(app)}
                 onEdit={() => {
                   setSelectedApp(app);
                   modal.open();

--- a/src/data/scopeData.tsx
+++ b/src/data/scopeData.tsx
@@ -3,17 +3,17 @@ import { Mark } from "@mantine/core";
 export const scopeData = {
   openid: {
     title: "验证用户身份",
-    description: "允许应用通过 OpenID Connect 获取你的稳定用户标识。",
+    description: "允许应用确认当前登录的是你，并获取用于识别你的唯一标识。",
     high_risk: false,
   },
   profile: {
     title: "读取基本资料",
-    description: "包括你的用户名等基本资料，需要同时允许验证用户身份。",
+    description: "允许应用获取你的查分器用户名等基本资料。",
     high_risk: false,
   },
   email: {
     title: "读取邮箱地址",
-    description: "允许应用读取你的邮箱地址，需要同时允许验证用户身份。",
+    description: "允许应用获取你在查分器中绑定的邮箱地址。",
     high_risk: false,
   },
   read_user_profile: {

--- a/src/data/scopeData.tsx
+++ b/src/data/scopeData.tsx
@@ -17,8 +17,8 @@ export const scopeData = {
     high_risk: false,
   },
   read_user_profile: {
-    title: "读取用户信息",
-    description: "包括你的用户名、邮箱等基本信息。",
+    title: "读取站内账户资料（API）",
+    description: "通过查分器 API 读取你的用户名、邮箱等账户信息。",
     high_risk: false,
   },
   read_player: {
@@ -41,3 +41,26 @@ export const scopeData = {
     high_risk: true,
   },
 };
+
+export const scopeGroups = [
+  {
+    key: "oidc",
+    title: "登录与身份",
+    protocol: "OpenID Connect",
+    description: "用于识别登录用户；如需基本资料或邮箱，请在验证身份的基础上继续选择。",
+    scopes: ["openid", "profile", "email"],
+  },
+  {
+    key: "oauth",
+    title: "API 授权",
+    protocol: "OAuth 2.0",
+    description: "用于调用查分器 API，按应用实际需要选择最小权限范围。",
+    scopes: ["read_user_profile", "read_player", "write_player", "read_user_token"],
+  },
+] as const satisfies ReadonlyArray<{
+  key: string;
+  title: string;
+  protocol: string;
+  description: string;
+  scopes: ReadonlyArray<keyof typeof scopeData>;
+}>;

--- a/src/data/scopeData.tsx
+++ b/src/data/scopeData.tsx
@@ -47,14 +47,14 @@ export const scopeGroups = [
     key: "oauth",
     title: "API 授权",
     protocol: "OAuth 2.0",
-    description: "用于调用查分器 API，按应用实际需要选择最小权限范围。",
+    description: "调用查分器 API 所需的权限。",
     scopes: ["read_user_profile", "read_player", "write_player", "read_user_token"],
   },
   {
     key: "oidc",
     title: "登录与身份",
     protocol: "OpenID Connect",
-    description: "用于识别登录用户；如需基本资料或邮箱，请在验证身份的基础上继续选择。",
+    description: "用于登录并获取用户身份信息。",
     scopes: ["openid", "profile", "email"],
   },
 ] as const satisfies ReadonlyArray<{

--- a/src/data/scopeData.tsx
+++ b/src/data/scopeData.tsx
@@ -1,6 +1,21 @@
 import { Mark } from "@mantine/core";
 
 export const scopeData = {
+  openid: {
+    title: "验证用户身份",
+    description: "允许应用通过 OpenID Connect 获取你的稳定用户标识。",
+    high_risk: false,
+  },
+  profile: {
+    title: "读取基本资料",
+    description: "包括你的用户名等基本资料，需要同时允许验证用户身份。",
+    high_risk: false,
+  },
+  email: {
+    title: "读取邮箱地址",
+    description: "允许应用读取你的邮箱地址，需要同时允许验证用户身份。",
+    high_risk: false,
+  },
   read_user_profile: {
     title: "读取用户信息",
     description: "包括你的用户名、邮箱等基本信息。",

--- a/src/data/scopeData.tsx
+++ b/src/data/scopeData.tsx
@@ -17,8 +17,8 @@ export const scopeData = {
     high_risk: false,
   },
   read_user_profile: {
-    title: "读取站内账户资料（API）",
-    description: "通过查分器 API 读取你的用户名、邮箱等账户信息。",
+    title: "读取用户信息",
+    description: "包括你的用户名、邮箱等基本信息。",
     high_risk: false,
   },
   read_player: {
@@ -44,18 +44,18 @@ export const scopeData = {
 
 export const scopeGroups = [
   {
-    key: "oidc",
-    title: "登录与身份",
-    protocol: "OpenID Connect",
-    description: "用于识别登录用户；如需基本资料或邮箱，请在验证身份的基础上继续选择。",
-    scopes: ["openid", "profile", "email"],
-  },
-  {
     key: "oauth",
     title: "API 授权",
     protocol: "OAuth 2.0",
     description: "用于调用查分器 API，按应用实际需要选择最小权限范围。",
     scopes: ["read_user_profile", "read_player", "write_player", "read_user_token"],
+  },
+  {
+    key: "oidc",
+    title: "登录与身份",
+    protocol: "OpenID Connect",
+    description: "用于识别登录用户；如需基本资料或邮箱，请在验证身份的基础上继续选择。",
+    scopes: ["openid", "profile", "email"],
   },
 ] as const satisfies ReadonlyArray<{
   key: string;

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -89,6 +89,9 @@ export default function Authorize() {
     [params],
   );
   const [selectedScopes, setSelectedScopes] = useState<string[]>(requestedScopes);
+  useEffect(() => {
+    setSelectedScopes(requestedScopes);
+  }, [requestedScopes]);
   // only ever offer/grant scopes the client is actually registered for — clients may over-request
   // (e.g. an MCP client reading the AS metadata picks up read_user_token, which is not an MCP scope)
   const registeredScope = app?.scope ?? "";

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -155,7 +155,7 @@ export default function Authorize() {
       void handleAuthorize();
     }, 3000);
     return () => window.clearTimeout(timer);
-  }, [app, handleAuthorize, redirectUri]);
+  }, [app, effectiveScopes.length, handleAuthorize, redirectUri]);
 
   const handleDeny = () => {
     if (!app || !redirectUri) return;

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -80,6 +80,7 @@ export default function Authorize() {
       const resource = params.get("resource");
       const data = await confirmOAuthAuthorize({
         client_id: params.get("client_id") || "",
+        response_type: params.get("response_type") || "",
         redirect_uri: params.get("redirect_uri") || "",
         scope: app.is_dynamic
           ? selectedScopes.filter((s) => allowedScopes.includes(s)).join(" ")
@@ -87,6 +88,7 @@ export default function Authorize() {
         code_challenge: params.get("code_challenge") || "",
         code_challenge_method: params.get("code_challenge_method") || "",
         state: params.get("state") || "",
+        nonce: params.get("nonce") || "",
         ...(resource ? { resource } : {}),
       });
       if (isOOBRedirectUri(redirectUri)) {
@@ -198,7 +200,16 @@ export default function Authorize() {
             {app.is_dynamic ? "请选择要授予该应用的权限：" : "该应用将会获得以下权限："}
           </Text>
           {app.is_dynamic ? (
-            <Checkbox.Group value={selectedScopes} onChange={setSelectedScopes}>
+            <Checkbox.Group
+              value={selectedScopes}
+              onChange={(scopes) =>
+                setSelectedScopes(
+                  scopes.includes("openid")
+                    ? scopes
+                    : scopes.filter((scope) => scope !== "profile" && scope !== "email"),
+                )
+              }
+            >
               <Stack gap="sm" mt="md">
                 {allowedScopes.map((scope) => {
                   const s = scope as keyof typeof scopeData;
@@ -210,6 +221,10 @@ export default function Authorize() {
                       value={scope}
                       label={meta ? meta.title : scope}
                       description={meta?.description}
+                      disabled={
+                        (scope === "profile" || scope === "email") &&
+                        !selectedScopes.includes("openid")
+                      }
                     />
                   );
                 })}

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -144,6 +144,7 @@ export default function Authorize() {
     if (
       !app ||
       !redirectUri ||
+      effectiveScopes.length === 0 ||
       app.is_dynamic ||
       !app.user_authorized ||
       isOOBRedirectUri(redirectUri)
@@ -178,7 +179,7 @@ export default function Authorize() {
     );
   }
 
-  if (error || !app || !redirectUri) {
+  if (error || !app || !redirectUri || allowedScopes.length === 0) {
     return (
       <Container className={classes.root} size={420}>
         <Alert
@@ -193,7 +194,9 @@ export default function Authorize() {
               ? error.message
               : !redirectUri
                 ? "请求中的回调地址缺失或未在应用中注册"
-                : "无法读取应用信息"}
+                : allowedScopes.length === 0
+                  ? "应用未请求任何可授权的权限"
+                  : "无法读取应用信息"}
           </Text>
         </Alert>
       </Container>

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Title,
   Text,
@@ -51,34 +51,34 @@ function isAppSchemeRedirectUri(redirectUri: string | null): boolean {
 
 export default function Authorize() {
   const pageContext = usePageContext();
-  const params = new URLSearchParams(pageContext.urlParsed.search);
+  const params = useMemo(
+    () => new URLSearchParams(pageContext.urlParsed.search),
+    [pageContext.urlParsed.search],
+  );
   const { app, isLoading, error } = useOAuthApp(params);
-  const confirmOAuthAuthorize = useConfirmOAuthAuthorize();
+  const { mutateAsync: confirmOAuthAuthorize } = useConfirmOAuthAuthorize();
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [code, setCode] = useState("");
-  const requestedScopes = (params.get("scope") || "").split(" ").filter(Boolean);
+  const redirectUri = params.get("redirect_uri");
+  const requestedScopes = useMemo(
+    () => (params.get("scope") || "").split(" ").filter(Boolean),
+    [params],
+  );
   const [selectedScopes, setSelectedScopes] = useState<string[]>(requestedScopes);
   // only ever offer/grant scopes the client is actually registered for — clients may over-request
   // (e.g. an MCP client reading the AS metadata picks up read_user_token, which is not an MCP scope)
-  const registeredScopes = (app?.scope ?? "").split(" ").filter(Boolean);
-  const allowedScopes = requestedScopes.filter((s) => registeredScopes.includes(s));
+  const registeredScope = app?.scope ?? "";
+  const allowedScopes = useMemo(() => {
+    const registeredScopes = registeredScope.split(" ").filter(Boolean);
+    return requestedScopes.filter((scope) => registeredScopes.includes(scope));
+  }, [registeredScope, requestedScopes]);
 
-  useEffect(() => {
-    if (!app) return;
-    if (!app.is_dynamic && app.user_authorized && !isOOBRedirectUri(app.redirect_uri)) {
-      setCode("authorized");
-      setTimeout(() => {
-        handleAuthorize();
-      }, 3000);
-    }
-  }, [app]);
-
-  const handleAuthorize = async () => {
+  const handleAuthorize = useCallback(async () => {
     if (!app) return;
     setIsAuthorizing(true);
     try {
       const resource = params.get("resource");
-      const data = await confirmOAuthAuthorize.mutateAsync({
+      const data = await confirmOAuthAuthorize({
         client_id: params.get("client_id") || "",
         redirect_uri: params.get("redirect_uri") || "",
         scope: app.is_dynamic
@@ -89,10 +89,10 @@ export default function Authorize() {
         state: params.get("state") || "",
         ...(resource ? { resource } : {}),
       });
-      if (isOOBRedirectUri(app.redirect_uri)) {
+      if (isOOBRedirectUri(redirectUri)) {
         setCode(data.code);
-      } else {
-        const redirect = new URL(app.redirect_uri);
+      } else if (redirectUri) {
+        const redirect = new URL(redirectUri);
         redirect.searchParams.set("code", data.code);
         if (data.state) {
           redirect.searchParams.set("state", data.state);
@@ -104,14 +104,23 @@ export default function Authorize() {
     } finally {
       setIsAuthorizing(false);
     }
-  };
+  }, [allowedScopes, app, confirmOAuthAuthorize, params, redirectUri, selectedScopes]);
+
+  useEffect(() => {
+    if (!app || app.is_dynamic || !app.user_authorized || isOOBRedirectUri(redirectUri)) return;
+    setCode("authorized");
+    const timer = window.setTimeout(() => {
+      void handleAuthorize();
+    }, 3000);
+    return () => window.clearTimeout(timer);
+  }, [app, handleAuthorize, redirectUri]);
 
   const handleDeny = () => {
     if (!app) return;
-    if (isOOBRedirectUri(app.redirect_uri)) {
+    if (isOOBRedirectUri(redirectUri)) {
       setCode("unauthorized");
-    } else {
-      const redirect = new URL(app.redirect_uri);
+    } else if (redirectUri) {
+      const redirect = new URL(redirectUri);
       redirect.searchParams.set("error", "access_denied");
       if (params.get("state")) {
         redirect.searchParams.set("state", params.get("state") || "");
@@ -300,13 +309,13 @@ export default function Authorize() {
               </Button>
             </Group>
 
-            {isOOBRedirectUri(app.redirect_uri) ? (
+            {isOOBRedirectUri(redirectUri) ? (
               <Box mt="sm">
                 <Text size="xs" c="dimmed">
                   授权后将会显示授权码，请将其复制到应用中
                 </Text>
               </Box>
-            ) : isAppSchemeRedirectUri(app.redirect_uri) ? (
+            ) : isAppSchemeRedirectUri(redirectUri) ? (
               <Box mt="sm">
                 <Text size="xs" c="dimmed">
                   授权后将会跳转回
@@ -321,7 +330,7 @@ export default function Authorize() {
                   授权后将会跳转到
                 </Text>
                 <Text size="xs" fw={500} mt={2}>
-                  {app.redirect_uri.replace(/^(http|https):\/\/([^/]+).+/, "$1://$2")}
+                  {redirectUri?.replace(/^(http|https):\/\/([^/]+).+/, "$1://$2")}
                 </Text>
               </Box>
             )}

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -100,7 +100,7 @@ export default function Authorize() {
   }, [registeredScope, requestedScopes]);
 
   const handleAuthorize = useCallback(async () => {
-    if (!app) return;
+    if (!app || !redirectUri) return;
     setIsAuthorizing(true);
     try {
       const resource = params.get("resource");
@@ -135,7 +135,14 @@ export default function Authorize() {
   }, [allowedScopes, app, confirmOAuthAuthorize, params, redirectUri, selectedScopes]);
 
   useEffect(() => {
-    if (!app || app.is_dynamic || !app.user_authorized || isOOBRedirectUri(redirectUri)) return;
+    if (
+      !app ||
+      !redirectUri ||
+      app.is_dynamic ||
+      !app.user_authorized ||
+      isOOBRedirectUri(redirectUri)
+    )
+      return;
     setCode("authorized");
     const timer = window.setTimeout(() => {
       void handleAuthorize();
@@ -144,7 +151,7 @@ export default function Authorize() {
   }, [app, handleAuthorize, redirectUri]);
 
   const handleDeny = () => {
-    if (!app) return;
+    if (!app || !redirectUri) return;
     if (isOOBRedirectUri(redirectUri)) {
       setCode("unauthorized");
     } else if (redirectUri) {
@@ -165,17 +172,23 @@ export default function Authorize() {
     );
   }
 
-  if (error || !app) {
+  if (error || !app || !redirectUri) {
     return (
       <Container className={classes.root} size={420}>
         <Alert
           radius="md"
           icon={<IconExclamationCircle />}
-          title={`无效的应用`}
+          title="无效的授权请求"
           color="red"
           mb="md"
         >
-          <Text size="sm">{error instanceof Error && error.message}</Text>
+          <Text size="sm">
+            {error instanceof Error
+              ? error.message
+              : !redirectUri
+                ? "请求中的回调地址缺失或未在应用中注册"
+                : "无法读取应用信息"}
+          </Text>
         </Alert>
       </Container>
     );

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -98,9 +98,16 @@ export default function Authorize() {
       requestedScopes.filter((scope) => registeredScopes.includes(scope)),
     );
   }, [registeredScope, requestedScopes]);
+  const effectiveScopes = useMemo(
+    () =>
+      app?.is_dynamic
+        ? selectedScopes.filter((scope) => allowedScopes.includes(scope))
+        : allowedScopes,
+    [allowedScopes, app?.is_dynamic, selectedScopes],
+  );
 
   const handleAuthorize = useCallback(async () => {
-    if (!app || !redirectUri) return;
+    if (!app || !redirectUri || effectiveScopes.length === 0) return;
     setIsAuthorizing(true);
     try {
       const resource = params.get("resource");
@@ -109,9 +116,7 @@ export default function Authorize() {
         client_id: params.get("client_id") || "",
         response_type: params.get("response_type") || "",
         redirect_uri: redirectUri || "",
-        scope: app.is_dynamic
-          ? selectedScopes.filter((s) => allowedScopes.includes(s)).join(" ")
-          : allowedScopes.join(" "),
+        scope: effectiveScopes.join(" "),
         code_challenge: params.get("code_challenge") || "",
         code_challenge_method: params.get("code_challenge_method") || "",
         state: params.get("state") || "",
@@ -133,7 +138,7 @@ export default function Authorize() {
     } finally {
       setIsAuthorizing(false);
     }
-  }, [allowedScopes, app, confirmOAuthAuthorize, params, redirectUri, selectedScopes]);
+  }, [app, confirmOAuthAuthorize, effectiveScopes, params, redirectUri]);
 
   useEffect(() => {
     if (
@@ -352,7 +357,7 @@ export default function Authorize() {
               <Button
                 onClick={handleAuthorize}
                 loading={isAuthorizing}
-                disabled={app.is_dynamic && selectedScopes.length === 0}
+                disabled={app.is_dynamic && effectiveScopes.length === 0}
               >
                 授权应用
               </Button>

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -64,7 +64,8 @@ export default function Authorize() {
   const { mutateAsync: confirmOAuthAuthorize } = useConfirmOAuthAuthorize();
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [code, setCode] = useState("");
-  const redirectUri = params.get("redirect_uri");
+  const redirectUri =
+    params.get("redirect_uri") || app?.redirect_uri || app?.redirect_uris?.[0] || null;
   const requestedScopes = useMemo(
     () => (params.get("scope") || "").split(" ").filter(Boolean),
     [params],
@@ -88,7 +89,7 @@ export default function Authorize() {
       const data = await confirmOAuthAuthorize({
         client_id: params.get("client_id") || "",
         response_type: params.get("response_type") || "",
-        redirect_uri: params.get("redirect_uri") || "",
+        redirect_uri: redirectUri || "",
         scope: app.is_dynamic
           ? selectedScopes.filter((s) => allowedScopes.includes(s)).join(" ")
           : allowedScopes.join(" "),

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -104,6 +104,7 @@ export default function Authorize() {
     setIsAuthorizing(true);
     try {
       const resource = params.get("resource");
+      const nonce = params.get("nonce");
       const data = await confirmOAuthAuthorize({
         client_id: params.get("client_id") || "",
         response_type: params.get("response_type") || "",
@@ -114,7 +115,7 @@ export default function Authorize() {
         code_challenge: params.get("code_challenge") || "",
         code_challenge_method: params.get("code_challenge_method") || "",
         state: params.get("state") || "",
-        nonce: params.get("nonce") || "",
+        ...(nonce ? { nonce } : {}),
         ...(resource ? { resource } : {}),
       });
       if (isOOBRedirectUri(redirectUri)) {

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -110,19 +110,24 @@ export default function Authorize() {
   );
 
   const handleAuthorize = useCallback(async () => {
-    if (!app || !redirectUri || effectiveScopes.length === 0) return;
+    const clientId = params.get("client_id");
+    if (!app || !clientId || !redirectUri || effectiveScopes.length === 0) return;
     setIsAuthorizing(true);
     try {
       const resource = params.get("resource");
       const nonce = params.get("nonce");
+      const responseType = params.get("response_type");
+      const codeChallenge = params.get("code_challenge");
+      const codeChallengeMethod = params.get("code_challenge_method");
+      const state = params.get("state");
       const data = await confirmOAuthAuthorize({
-        client_id: params.get("client_id") || "",
-        response_type: params.get("response_type") || "",
-        redirect_uri: redirectUri || "",
+        client_id: clientId,
+        redirect_uri: redirectUri,
         scope: effectiveScopes.join(" "),
-        code_challenge: params.get("code_challenge") || "",
-        code_challenge_method: params.get("code_challenge_method") || "",
-        state: params.get("state") || "",
+        ...(responseType ? { response_type: responseType } : {}),
+        ...(codeChallenge ? { code_challenge: codeChallenge } : {}),
+        ...(codeChallengeMethod ? { code_challenge_method: codeChallengeMethod } : {}),
+        ...(state ? { state } : {}),
         ...(nonce ? { nonce } : {}),
         ...(resource ? { resource } : {}),
       });

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -49,6 +49,11 @@ function isAppSchemeRedirectUri(redirectUri: string | null): boolean {
   }
 }
 
+function filterDependentOIDCScopes(scopes: string[]): string[] {
+  if (scopes.includes("openid")) return scopes;
+  return scopes.filter((scope) => scope !== "profile" && scope !== "email");
+}
+
 export default function Authorize() {
   const pageContext = usePageContext();
   const params = useMemo(
@@ -70,7 +75,9 @@ export default function Authorize() {
   const registeredScope = app?.scope ?? "";
   const allowedScopes = useMemo(() => {
     const registeredScopes = registeredScope.split(" ").filter(Boolean);
-    return requestedScopes.filter((scope) => registeredScopes.includes(scope));
+    return filterDependentOIDCScopes(
+      requestedScopes.filter((scope) => registeredScopes.includes(scope)),
+    );
   }, [registeredScope, requestedScopes]);
 
   const handleAuthorize = useCallback(async () => {
@@ -202,13 +209,7 @@ export default function Authorize() {
           {app.is_dynamic ? (
             <Checkbox.Group
               value={selectedScopes}
-              onChange={(scopes) =>
-                setSelectedScopes(
-                  scopes.includes("openid")
-                    ? scopes
-                    : scopes.filter((scope) => scope !== "profile" && scope !== "email"),
-                )
-              }
+              onChange={(scopes) => setSelectedScopes(filterDependentOIDCScopes(scopes))}
             >
               <Stack gap="sm" mt="md">
                 {allowedScopes.map((scope) => {

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -54,6 +54,21 @@ function filterDependentOIDCScopes(scopes: string[]): string[] {
   return scopes.filter((scope) => scope !== "profile" && scope !== "email");
 }
 
+function resolveRedirectUri(
+  redirectUris: string[] | undefined,
+  legacyRedirectUri: string | undefined,
+  requestedRedirectUri: string | null,
+): string | null {
+  let registeredRedirectUris = redirectUris ?? [];
+  if (registeredRedirectUris.length === 0 && legacyRedirectUri) {
+    registeredRedirectUris = [legacyRedirectUri];
+  }
+  if (requestedRedirectUri) {
+    return registeredRedirectUris.includes(requestedRedirectUri) ? requestedRedirectUri : null;
+  }
+  return registeredRedirectUris.length === 1 ? registeredRedirectUris[0] : null;
+}
+
 export default function Authorize() {
   const pageContext = usePageContext();
   const params = useMemo(
@@ -64,8 +79,11 @@ export default function Authorize() {
   const { mutateAsync: confirmOAuthAuthorize } = useConfirmOAuthAuthorize();
   const [isAuthorizing, setIsAuthorizing] = useState(false);
   const [code, setCode] = useState("");
-  const redirectUri =
-    params.get("redirect_uri") || app?.redirect_uri || app?.redirect_uris?.[0] || null;
+  const redirectUri = resolveRedirectUri(
+    app?.redirect_uris,
+    app?.redirect_uri,
+    params.get("redirect_uri"),
+  );
   const requestedScopes = useMemo(
     () => (params.get("scope") || "").split(" ").filter(Boolean),
     [params],

--- a/src/pages/user/OAuth/Authorize.tsx
+++ b/src/pages/user/OAuth/Authorize.tsx
@@ -88,6 +88,9 @@ export default function Authorize() {
     () => (params.get("scope") || "").split(" ").filter(Boolean),
     [params],
   );
+  const hasInvalidOIDCDependency =
+    !requestedScopes.includes("openid") &&
+    requestedScopes.some((scope) => scope === "profile" || scope === "email");
   const [selectedScopes, setSelectedScopes] = useState<string[]>(requestedScopes);
   useEffect(() => {
     setSelectedScopes(requestedScopes);
@@ -187,7 +190,7 @@ export default function Authorize() {
     );
   }
 
-  if (error || !app || !redirectUri || allowedScopes.length === 0) {
+  if (error || !app || !redirectUri || hasInvalidOIDCDependency || allowedScopes.length === 0) {
     return (
       <Container className={classes.root} size={420}>
         <Alert
@@ -202,9 +205,11 @@ export default function Authorize() {
               ? error.message
               : !redirectUri
                 ? "请求中的回调地址缺失或未在应用中注册"
-                : allowedScopes.length === 0
-                  ? "应用未请求任何可授权的权限"
-                  : "无法读取应用信息"}
+                : hasInvalidOIDCDependency
+                  ? "profile 和 email 权限必须同时请求 openid"
+                  : allowedScopes.length === 0
+                    ? "应用未请求任何可授权的权限"
+                    : "无法读取应用信息"}
           </Text>
         </Alert>
       </Container>

--- a/src/types/developer.d.ts
+++ b/src/types/developer.d.ts
@@ -27,7 +27,8 @@ export interface OAuthAppProps {
   description?: string;
   website?: string;
   logo_url?: string;
-  redirect_uri: string;
+  redirect_uri?: string;
+  redirect_uris: string[];
   scope: string;
   create_time?: string;
   update_time?: string;

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -82,12 +82,12 @@ export const validateRedirectUri = (uri: string) => {
       if (!parsed.hostname) {
         return "回调地址必须包含有效的主机名";
       }
+      const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
       if (
         scheme === "http" &&
-        parsed.hostname !== "localhost" &&
-        parsed.hostname !== "127.0.0.1" &&
-        parsed.hostname !== "[::1]" &&
-        parsed.hostname !== "::1"
+        hostname !== "localhost" &&
+        hostname !== "127.0.0.1" &&
+        hostname !== "::1"
       ) {
         return "不安全的回调地址，HTTP 协议仅允许 localhost、127.0.0.1 或 [::1]";
       }

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -79,7 +79,12 @@ export const validateRedirectUri = (uri: string) => {
       if (!parsed.hostname) {
         return "回调地址必须包含有效的主机名";
       }
-      if (scheme === "http" && parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
+      if (
+        scheme === "http" &&
+        parsed.hostname !== "localhost" &&
+        parsed.hostname !== "127.0.0.1" &&
+        parsed.hostname !== "[::1]"
+      ) {
         return "不安全的回调地址，HTTP 协议仅允许 localhost 或 127.0.0.1";
       }
     } else {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -85,7 +85,7 @@ export const validateRedirectUri = (uri: string) => {
         parsed.hostname !== "127.0.0.1" &&
         parsed.hostname !== "[::1]"
       ) {
-        return "不安全的回调地址，HTTP 协议仅允许 localhost 或 127.0.0.1";
+        return "不安全的回调地址，HTTP 协议仅允许 localhost、127.0.0.1 或 [::1]";
       }
     } else {
       if (scheme.length < 2) {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -72,6 +72,9 @@ export const validateRedirectUri = (uri: string) => {
     if (["javascript", "data", "file", "vbscript"].includes(scheme)) {
       return "回调地址使用了不安全的协议";
     }
+    if (parsed.username || parsed.password) {
+      return "回调地址不能包含用户名或密码";
+    }
     if (parsed.hash) {
       return "回调地址不能包含哈希片段";
     }

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -99,6 +99,7 @@ export const validateRedirectUri = (uri: string) => {
         return "自定义协议的回调地址协议部分必须以字母开头，并且只能包含字母、数字、加号、点和连字符";
       }
     }
+    return null;
   } catch (e) {
     return "回调地址格式不正确";
   }

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -86,7 +86,8 @@ export const validateRedirectUri = (uri: string) => {
         scheme === "http" &&
         parsed.hostname !== "localhost" &&
         parsed.hostname !== "127.0.0.1" &&
-        parsed.hostname !== "[::1]"
+        parsed.hostname !== "[::1]" &&
+        parsed.hostname !== "::1"
       ) {
         return "不安全的回调地址，HTTP 协议仅允许 localhost、127.0.0.1 或 [::1]";
       }


### PR DESCRIPTION
## What changed

- support multiple OAuth redirect URIs in the developer UI
- provide a single callback selector for generated authorization links
- add user-facing `openid`, `profile`, and `email` consent copy
- group API authorization and login/identity scopes in a compact Mantine Accordion
- keep API authorization first, show selected counts, and collapse groups by default
- enforce the `openid` dependency for OIDC profile and email scopes

## Why

OAuth API permissions and OIDC identity scopes have different purposes. Grouping them reduces ambiguity while still allowing applications to combine login and API access.

## Impact

Developers get a more compact modal and clearer permission model, while end users see plain-language identity consent descriptions.

## Validation

- `yarn tsc --noEmit`
- targeted ESLint check (0 errors)
- `oxfmt --check`