### PR TITLE
fix(chart-engine): 偏心烟花特效按触发位置放大峰值，覆盖整个播放圆

### DIFF
--- a/packages/maimai-chart-engine/src/renderers/TouchRenderer.ts
+++ b/packages/maimai-chart-engine/src/renderers/TouchRenderer.ts
@@ -18,6 +18,8 @@ const FIREWORK_DURATION_MS = 1333;
 // 星爆最大可见半径：baseRadius(radius/4.5) × scale 峰值 5.0，留 5% 边距。
 const FIREWORK_EXTENT_RATIO = (5.0 / 4.5) * 1.05;
 const FIREWORK_SCALE_PEAK = 5.0;
+// 精灵/掩膜相对峰值半径的 5% 边距（与 FIREWORK_EXTENT_RATIO 同源）。
+const FIREWORK_EXTENT_MARGIN = 1.05;
 // scale 低于此值走矢量绘制（成本 ∝ 面积），达到后切精灵（缩小率 ≤2:1 无极端采样）。
 const FIREWORK_SPRITE_MIN_SCALE = 2.5;
 const FIREWORK_HOLE_START_SEC = 0.6;
@@ -26,6 +28,19 @@ const FIREWORK_END_SEC = 1.1;
 // 烟花触发时刻
 export function fireworkTriggerMs(note: TouchNote | TouchHoldStartNote): number {
   return note.type === "touch-hold-start" ? note.timingMs + note.durationMs : note.timingMs;
+}
+
+/** 烟花峰值半径：至少覆盖播放圆最远端；圆心触发保持原大小（radius × 5/4.5）。 */
+function fireworkCoveragePeakRadius(
+  playRadius: number,
+  playCenterX: number,
+  playCenterY: number,
+  originX: number,
+  originY: number,
+): number {
+  const centeredPeakRadius = playRadius * (FIREWORK_SCALE_PEAK / 4.5);
+  const distanceFromCenter = Math.hypot(originX - playCenterX, originY - playCenterY);
+  return Math.max(centeredPeakRadius, playRadius + distanceFromCenter);
 }
 
 // 15 片 pastel wedge，颜色循环。
@@ -851,13 +866,23 @@ export class TouchRenderer extends BaseRenderer {
     const position = this.getTouchPosition(latestNote.position);
     const rotation = (ageMs / FIREWORK_DURATION_MS) * ((72 * Math.PI) / 180);
     const ctx = this.context.ctx;
-    const half = this.context.radius * FIREWORK_EXTENT_RATIO;
+    const centeredPeakRadius = (this.context.radius / 4.5) * FIREWORK_SCALE_PEAK;
+    const peakRadius = fireworkCoveragePeakRadius(
+      this.context.radius,
+      this.context.centerX,
+      this.context.centerY,
+      position.x,
+      position.y,
+    );
+    const coverageMultiplier = peakRadius / centeredPeakRadius;
+    const effectScale = scale * coverageMultiplier;
+    const half = peakRadius * FIREWORK_EXTENT_MARGIN;
 
     if (tSec <= FIREWORK_HOLE_START_SEC) {
       // 成长期无掩膜：小 scale 走矢量，达阈值切精灵。
-      if (scale > 0 && scale < FIREWORK_SPRITE_MIN_SCALE) {
-        this.drawWedgesVector(ctx, position.x, position.y, scale, rotation);
-      } else if (scale > 0) {
+      if (effectScale > 0 && effectScale < FIREWORK_SPRITE_MIN_SCALE) {
+        this.drawWedgesVector(ctx, position.x, position.y, effectScale, rotation);
+      } else if (effectScale > 0) {
         const drawHalf = half * (scale / FIREWORK_SCALE_PEAK);
         ctx.save();
         ctx.translate(position.x, position.y);
@@ -880,7 +905,7 @@ export class TouchRenderer extends BaseRenderer {
     this.drawFireworkBalls(scratch, 0, 0, tSec - 0.1);
 
     // 掩膜 = 实心核心 + 羽化边缘，从中心扩张擦除。
-    const outerR = (this.context.radius / 4.5) * scale;
+    const outerR = (this.context.radius / 4.5) * effectScale;
     const holeSpan = FIREWORK_END_SEC - FIREWORK_HOLE_START_SEC;
     const linearU = Math.min(1, (tSec - FIREWORK_HOLE_START_SEC) / holeSpan);
     // alpha 前 20% 快速升到 1 让实心 mask 早早可见；尺寸 smoothstep 起停柔和。


### PR DESCRIPTION
## 问题

烟花特效（touch `f` 标记）的峰值大小固定：楔形外径 = `radius/4.5 × 5.0`，
只有圆心（C 区）触发时才能铺满整个判定圈；边缘传感器（A/D/E 区，距圆心最远
0.854r）触发的烟花外沿只能到达 1.11r，圈内远侧一片区域照不到，且溢出部分被
内切圆裁剪，视觉上"只亮半边"。

## 修复

新增私有纯函数 `fireworkCoveragePeakRadius`（TouchRenderer.ts）：
```
peakRadius = max(radius × 5/4.5, radius + 触发点到圆心距离)
```

- 圆心触发时 `peakRadius = radius × 5/4.5`，与原实现完全一致，无行为变化
- 偏心触发时峰值半径至少覆盖播放圆最远端，星爆铺满整个判定圈

渲染侧按位置整体放大（`effectScale = scale × coverageMultiplier`），
矢量楔形、精灵绘制、`destination-out` 消散掩膜统一跟随，消散期 scratch
尺寸随 `half` 自动调整，无需单独改动。

## 效果

- 圆心烟花：大小与修复前一致
- 边缘烟花（如 `A4f`、`D7f`、`B6/E6/D6f`）：铺满整个播放圆，对齐街机原版
  烟花播满屏幕的表现

## 验证

- `yarn build`（tsc + vite）通过
- 改动文件 eslint（`--max-warnings 0`）通过
- 手动验证：`/chart?chart_id=11663&difficulty=4`（《系ぎて》Re:MASTER，
  含大量 A/B/D/E 区烟花）——圆心大小不变、边缘铺满全圆

|修改前|修改后|
|--|--|
<img width="1920" height="958" alt="谱面预览  maimai DX 查分器 - Google Chrome_2026-08-05_22-29-09" src="https://github.com/user-attachments/assets/2623a820-f5e5-4b21-8e24-db212a6f91ad" />|<img width="1920" height="958" alt="谱面预览  maimai DX 查分器 - Google Chrome_2026-08-05_22-29-15" src="https://github.com/user-attachments/assets/81e11737-f5ca-4fff-a9f0-d99c245754e2" />|