### PR TITLE
feat(account): require verified email for developer applications

### DIFF
--- a/public/docs/developer-guide.md
+++ b/public/docs/developer-guide.md
@@ -10,7 +10,7 @@
 
 ### 1. 获取 API 密钥
 
-- **开发者 API**：前往[开发者面板](/developer)申请成为开发者，获取开发者 API 密钥。
+- **开发者 API**：完成邮箱验证后，前往[开发者面板](/developer)申请成为开发者，获取开发者 API 密钥。
 - **个人 API**：前往[账号详情](/user/profile)生成个人 API 密钥。
 - **OAuth API**：参见 [OAuth 接入指南](/docs/oauth-guide)。
 

--- a/src/components/Profile/UserSection.tsx
+++ b/src/components/Profile/UserSection.tsx
@@ -12,16 +12,13 @@ import classes from "./Profile.module.css";
 import { openRetryModal } from "@/utils/modal.tsx";
 import { notifications } from "@mantine/notifications";
 import { useUser } from "@/hooks/queries/useUser.ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { emailVerificationSentMessage } from "@/utils/emailVerification.ts";
+import { useEmailVerificationPolling } from "@/hooks/useEmailVerificationPolling.ts";
 
 interface FormValues {
   name: string;
   email: string;
-}
-
-function verificationEmailSentMessage(expiresIn?: number): string {
-  if (!expiresIn || expiresIn <= 0) return "请尽快前往邮箱完成验证。";
-  return `请在 ${Math.ceil(expiresIn / 60)} 分钟内前往邮箱完成验证。`;
 }
 
 export const UserSection = () => {
@@ -32,6 +29,25 @@ export const UserSection = () => {
   const { mutate: mutateUpdateProfile } = useUpdateUserProfile();
   const { mutate: sendEmailVerification, isPending: isSendingEmailVerification } =
     useSendEmailVerification();
+  const {
+    checkNow: checkEmailVerification,
+    isChecking: isCheckingEmailVerification,
+    timedOut: emailVerificationPollingTimedOut,
+  } = useEmailVerificationPolling({
+    active: verificationSent,
+    verified: user?.email_verified ?? false,
+    invalidate,
+  });
+
+  useEffect(() => {
+    if (!verificationSent || !user?.email_verified) return;
+    setVerificationSent(false);
+    notifications.show({
+      title: "邮箱验证成功",
+      message: "当前邮箱已经完成验证。",
+      color: "green",
+    });
+  }, [user?.email_verified, verificationSent]);
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -92,7 +108,7 @@ export const UserSection = () => {
         }
         notifications.show({
           title: "验证邮件已发送",
-          message: verificationEmailSentMessage(result.expires_in),
+          message: emailVerificationSentMessage(result.expires_in),
           color: "green",
         });
         setVerificationSent(true);
@@ -148,21 +164,38 @@ export const UserSection = () => {
         {!user.email_verified && (
           <Group gap={0} mt={4}>
             <Text size="xs" c="dimmed">
-              {form.values.email ? "请先保存新的邮箱地址。" : "当前邮箱尚未验证。"}
+              {form.values.email
+                ? "请先保存新的邮箱地址。"
+                : verificationSent
+                  ? emailVerificationPollingTimedOut
+                    ? "自动检查已暂停，可手动检查验证状态。"
+                    : "验证邮件已发送，正在等待验证。"
+                  : "当前邮箱尚未验证。"}
             </Text>
-            {!form.values.email && (
-              <Button
-                type="button"
-                size="compact-xs"
-                variant="subtle"
-                px={4}
-                loading={isSendingEmailVerification}
-                disabled={verificationSent}
-                onClick={sendEmailVerificationHandler}
-              >
-                {verificationSent ? "验证邮件已发送" : "发送验证邮件"}
-              </Button>
-            )}
+            {!form.values.email &&
+              (verificationSent ? (
+                <Button
+                  type="button"
+                  size="compact-xs"
+                  variant="subtle"
+                  px={4}
+                  loading={isCheckingEmailVerification}
+                  onClick={() => void checkEmailVerification()}
+                >
+                  检查验证状态
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  size="compact-xs"
+                  variant="subtle"
+                  px={4}
+                  loading={isSendingEmailVerification}
+                  onClick={sendEmailVerificationHandler}
+                >
+                  发送验证邮件
+                </Button>
+              ))}
           </Group>
         )}
         <Group justify="flex-end" mt="md">

--- a/src/components/Scores/ScoreModal.tsx
+++ b/src/components/Scores/ScoreModal.tsx
@@ -112,13 +112,14 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
   const isLoggedOut = isTokenUndefined();
   const { comments } = useScoreComments({
     game,
-    params: !isLoggedOut
-      ? {
-          song_id: score ? `${score.id}` : "",
-          level_index: score ? `${score.level_index}` : "",
-          ...(score && "type" in score ? { song_type: score.type } : {}),
-        }
-      : undefined,
+    params:
+      !isLoggedOut && score
+        ? {
+            song_id: `${score.id}`,
+            level_index: `${score.level_index}`,
+            ...("type" in score ? { song_type: score.type } : {}),
+          }
+        : undefined,
   });
   const commentCount = comments.length;
 

--- a/src/hooks/queries/useScoreComments.ts
+++ b/src/hooks/queries/useScoreComments.ts
@@ -31,10 +31,11 @@ export const useScoreComments = ({ game, params }: UseScoreCommentsOptions) => {
   const queryClient = useQueryClient();
   const urlParams = new URLSearchParams(params as Record<string, string> | undefined);
   const key = queryKeys.comments.list(game, urlParams);
+  const enabled = Boolean(params?.song_id && params.level_index !== "");
 
   const { data, error, isLoading } = useQuery<Comment[]>({
     queryKey: key,
-    enabled: !!params,
+    enabled,
   });
 
   return {

--- a/src/hooks/queries/useUser.ts
+++ b/src/hooks/queries/useUser.ts
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { UserProps } from "@/types/user";
 import { queryKeys } from "./queryKeys.ts";
 
@@ -7,13 +8,21 @@ export const useUser = () => {
   const { data, error, isLoading } = useQuery<UserProps>({
     queryKey: queryKeys.user.profile(),
   });
+  const setData = useCallback(
+    (updater: UserProps | ((prev: UserProps | undefined) => UserProps | undefined)) =>
+      queryClient.setQueryData<UserProps>(queryKeys.user.profile(), updater),
+    [queryClient],
+  );
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.user.profile() }),
+    [queryClient],
+  );
 
   return {
     user: data,
     isLoading,
     error,
-    setData: (updater: UserProps | ((prev: UserProps | undefined) => UserProps | undefined)) =>
-      queryClient.setQueryData<UserProps>(queryKeys.user.profile(), updater),
-    invalidate: () => queryClient.invalidateQueries({ queryKey: queryKeys.user.profile() }),
+    setData,
+    invalidate,
   };
 };

--- a/src/hooks/queries/useUserToken.ts
+++ b/src/hooks/queries/useUserToken.ts
@@ -3,13 +3,16 @@ import { useQuery } from "@tanstack/react-query";
 import { getSentryUser, isTokenExpired, isTokenUndefined } from "@/utils/session.ts";
 import * as Sentry from "@sentry/react";
 import { queryKeys } from "./queryKeys.ts";
+import { refreshAccessToken } from "@/utils/api/api.ts";
 
 export const useUserToken = () => {
   const shouldFetch = !isTokenUndefined();
 
   const { data, error, isLoading, refetch } = useQuery<{ token: string }>({
     queryKey: queryKeys.user.refresh(),
+    queryFn: refreshAccessToken,
     enabled: shouldFetch,
+    retry: false,
   });
 
   useEffect(() => {

--- a/src/hooks/useEmailVerificationPolling.ts
+++ b/src/hooks/useEmailVerificationPolling.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const POLL_INTERVAL = 5_000;
+const POLL_TIMEOUT = 5 * 60_000;
+
+interface EmailVerificationPollingOptions {
+  active: boolean;
+  verified: boolean;
+  invalidate: () => Promise<unknown>;
+}
+
+export function useEmailVerificationPolling({
+  active,
+  verified,
+  invalidate,
+}: EmailVerificationPollingOptions) {
+  const startedAt = useRef<number | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const checkNow = useCallback(async () => {
+    setIsChecking(true);
+    try {
+      await invalidate();
+    } finally {
+      setIsChecking(false);
+    }
+  }, [invalidate]);
+
+  useEffect(() => {
+    if (!active || verified) {
+      startedAt.current = null;
+      if (timedOut) setTimedOut(false);
+      return;
+    }
+    if (timedOut) return;
+
+    const start = startedAt.current ?? Date.now();
+    startedAt.current = start;
+    const deadline = start + POLL_TIMEOUT;
+
+    const check = () => {
+      if (Date.now() >= deadline) {
+        setTimedOut(true);
+        return;
+      }
+      if (document.visibilityState === "visible") void invalidate();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") check();
+    };
+
+    const interval = window.setInterval(check, POLL_INTERVAL);
+    const timeout = window.setTimeout(() => setTimedOut(true), Math.max(0, deadline - Date.now()));
+    window.addEventListener("focus", check);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+      window.removeEventListener("focus", check);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [active, invalidate, timedOut, verified]);
+
+  return { checkNow, isChecking, timedOut };
+}

--- a/src/pages/+Layout.tsx
+++ b/src/pages/+Layout.tsx
@@ -31,6 +31,7 @@ import { useSiteConfig } from "@/hooks/queries/useSiteConfig.ts";
 import { useUserToken } from "@/hooks/queries/useUserToken.ts";
 import { useVersionChecker } from "@/hooks/useVersionChecker.tsx";
 import { HelmetProvider } from "react-helmet-async";
+import { APIError } from "@/utils/errors.ts";
 
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
@@ -128,7 +129,11 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
   const [game] = useGame();
 
   useEffect(() => {
-    if (userTokenError) {
+    const sessionExpired =
+      userTokenError instanceof APIError &&
+      (userTokenError.status === 401 || userTokenError.status === 403);
+
+    if (sessionExpired) {
       Sentry.setUser(null);
       logout();
 

--- a/src/pages/developer/Apply.tsx
+++ b/src/pages/developer/Apply.tsx
@@ -8,10 +8,12 @@ import {
   LoadingOverlay,
   Textarea,
   Card,
+  Alert,
 } from "@mantine/core";
 import { Container, rem } from "@mantine/core";
 import { Icon } from "@/components/MdiIcon";
 import { mdiCodeTags, mdiLink } from "@mdi/js";
+import { IconMail, IconMailCheck } from "@tabler/icons-react";
 import { useForm } from "@mantine/form";
 import classes from "../Form.module.css";
 import { openRetryModal } from "@/utils/modal.tsx";
@@ -20,6 +22,10 @@ import { validateText, validateUrl } from "@/utils/validator.ts";
 import { useDeveloper } from "@/hooks/queries/useDeveloper.ts";
 import { useSendDeveloperApply } from "@/hooks/mutations/useDeveloperMutations.ts";
 import { navigate } from "vike/client/router";
+import { useUser } from "@/hooks/queries/useUser.ts";
+import { useSendEmailVerification } from "@/hooks/mutations/useUserMutations.ts";
+import { emailVerificationSentMessage } from "@/utils/emailVerification.ts";
+import { useEmailVerificationPolling } from "@/hooks/useEmailVerificationPolling.ts";
 
 interface FormValues {
   name: string;
@@ -28,10 +34,27 @@ interface FormValues {
 }
 
 export default function DeveloperApply() {
-  const { developer, isLoading } = useDeveloper();
+  const { developer, isLoading: isDeveloperLoading } = useDeveloper();
+  const { user, isLoading: isUserLoading, invalidate: invalidateUser } = useUser();
   const { mutate: sendApply } = useSendDeveloperApply();
+  const { mutate: sendEmailVerification, isPending: isSendingEmailVerification } =
+    useSendEmailVerification();
   const [submitting, setSubmitting] = useState(false);
   const [applied, setApplied] = useState(false);
+  const [verificationSent, setVerificationSent] = useState(false);
+
+  const emailVerificationRequired = !developer && user?.email_verified !== true;
+  const showEmailVerificationRequired =
+    !isUserLoading && Boolean(user) && emailVerificationRequired;
+  const {
+    checkNow: checkEmailVerification,
+    isChecking: isCheckingEmailVerification,
+    timedOut: emailVerificationPollingTimedOut,
+  } = useEmailVerificationPolling({
+    active: verificationSent,
+    verified: user?.email_verified ?? false,
+    invalidate: invalidateUser,
+  });
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -52,6 +75,7 @@ export default function DeveloperApply() {
       reason: (value) => validateText(value, { allowEmpty: false, textLabel: "申请理由" }),
     },
   });
+  const setFormValues = form.setValues;
 
   const handleSubmit = (values: FormValues) => {
     setSubmitting(true);
@@ -74,20 +98,55 @@ export default function DeveloperApply() {
     });
   };
 
+  const sendEmailVerificationHandler = () => {
+    sendEmailVerification(undefined, {
+      onSuccess: (result) => {
+        if (result.email_verified) {
+          void invalidateUser();
+          notifications.show({
+            title: "邮箱已验证",
+            message: "当前邮箱已经完成验证。",
+            color: "green",
+          });
+          return;
+        }
+        notifications.show({
+          title: "验证邮件已发送",
+          message: emailVerificationSentMessage(result.expires_in),
+          color: "green",
+        });
+        setVerificationSent(true);
+      },
+      onError: (error) => {
+        openRetryModal("发送失败", `${error}`, sendEmailVerificationHandler);
+      },
+    });
+  };
+
   useEffect(() => {
     if (!developer) return;
 
     if (developer.api_key) {
       navigate("/developer", { overwriteLastHistoryEntry: true });
     } else {
-      form.setValues({
+      setFormValues({
         name: developer.name || "",
         url: developer.url || "",
         reason: developer.reason || "",
       });
       setApplied(true);
     }
-  }, [developer]);
+  }, [developer, setFormValues]);
+
+  useEffect(() => {
+    if (!verificationSent || !user?.email_verified) return;
+    setVerificationSent(false);
+    notifications.show({
+      title: "邮箱验证成功",
+      message: "你现在可以提交开发者申请。",
+      color: "green",
+    });
+  }, [user?.email_verified, verificationSent]);
 
   return (
     <Container className={classes.root} size={420}>
@@ -97,55 +156,112 @@ export default function DeveloperApply() {
       <Text c="dimmed" size="sm" ta="center" mt="sm">
         提交申请，通过审核后即可获取开发者 API 访问权限
       </Text>
-      <Card className={classes.card} withBorder shadow="md" p={30} mt={30} radius="md">
-        <LoadingOverlay visible={isLoading} overlayProps={{ radius: "sm", blur: 2 }} zIndex={2} />
-        <form onSubmit={form.onSubmit(handleSubmit)}>
-          <TextInput
-            name="name"
-            label="开发者名称"
-            variant="filled"
-            placeholder="请输入你本人或组织的名称"
-            mb="sm"
-            leftSection={<Icon path={mdiCodeTags} size={rem(16)} />}
-            disabled={applied}
-            {...form.getInputProps("name")}
+      {showEmailVerificationRequired ? (
+        <>
+          <Alert
+            variant="light"
+            icon={<IconMailCheck size={20} stroke={1.5} />}
+            title="申请前需要验证邮箱"
+            mt="xl"
+            radius="md"
+          >
+            验证邮箱有助于确认联系方式有效，并向你发送申请审核相关通知。
+          </Alert>
+          <Card className={classes.card} withBorder shadow="md" p={30} mt="md" radius="md">
+            <TextInput
+              label="邮箱"
+              variant="filled"
+              value={user?.email ?? ""}
+              readOnly
+              leftSection={<IconMail size={20} stroke={1.5} />}
+            />
+            <Text c="dimmed" size="xs" ta="left" mt={4}>
+              {verificationSent
+                ? emailVerificationPollingTimedOut
+                  ? "自动检查已暂停，可手动检查验证状态。"
+                  : "验证邮件已发送，正在等待验证。"
+                : "验证邮件将发送到当前账号绑定的邮箱。"}
+            </Text>
+            <Group justify="flex-end" mt="xl">
+              <Button
+                size="sm"
+                variant="default"
+                color="gray"
+                onClick={() => navigate("/user/profile")}
+              >
+                账号详情
+              </Button>
+              <Button
+                size="sm"
+                loading={
+                  verificationSent ? isCheckingEmailVerification : isSendingEmailVerification
+                }
+                onClick={
+                  verificationSent
+                    ? () => void checkEmailVerification()
+                    : sendEmailVerificationHandler
+                }
+              >
+                {verificationSent ? "检查验证状态" : "发送验证邮件"}
+              </Button>
+            </Group>
+          </Card>
+        </>
+      ) : (
+        <Card className={classes.card} withBorder shadow="md" p={30} mt={30} radius="md">
+          <LoadingOverlay
+            visible={isDeveloperLoading || isUserLoading}
+            overlayProps={{ radius: "sm", blur: 2 }}
+            zIndex={2}
           />
-          <TextInput
-            name="url"
-            label="开发者地址"
-            variant="filled"
-            placeholder="请输入你本人或组织的地址"
-            mb={4}
-            leftSection={<Icon path={mdiLink} size={rem(16)} />}
-            disabled={applied}
-            {...form.getInputProps("url")}
-          />
-          <Text c="dimmed" size="xs" ta="left" mb="sm">
-            可以是个人主页、GitHub 主页或组织主页等
-          </Text>
-          <Textarea
-            name="reason"
-            label="申请理由"
-            variant="filled"
-            placeholder="请输入你的申请理由"
-            mb="sm"
-            disabled={applied}
-            {...form.getInputProps("reason")}
-          />
-          <Group justify="space-between" mt="xl">
-            <div>
-              {applied && (
-                <Text size="xs" c="dimmed">
-                  你的申请正在受理中
-                </Text>
-              )}
-            </div>
-            <Button size="sm" type="submit" loading={submitting} disabled={applied}>
-              提交申请
-            </Button>
-          </Group>
-        </form>
-      </Card>
+          <form onSubmit={form.onSubmit(handleSubmit)}>
+            <TextInput
+              name="name"
+              label="开发者名称"
+              variant="filled"
+              placeholder="请输入你本人或组织的名称"
+              mb="sm"
+              leftSection={<Icon path={mdiCodeTags} size={rem(16)} />}
+              disabled={applied}
+              {...form.getInputProps("name")}
+            />
+            <TextInput
+              name="url"
+              label="开发者地址"
+              variant="filled"
+              placeholder="请输入你本人或组织的地址"
+              mb={4}
+              leftSection={<Icon path={mdiLink} size={rem(16)} />}
+              disabled={applied}
+              {...form.getInputProps("url")}
+            />
+            <Text c="dimmed" size="xs" ta="left" mb="sm">
+              可以是个人主页、GitHub 主页或组织主页等
+            </Text>
+            <Textarea
+              name="reason"
+              label="申请理由"
+              variant="filled"
+              placeholder="请输入你的申请理由"
+              mb="sm"
+              disabled={applied}
+              {...form.getInputProps("reason")}
+            />
+            <Group justify="space-between" mt="xl">
+              <div>
+                {applied && (
+                  <Text size="xs" c="dimmed">
+                    你的申请正在受理中
+                  </Text>
+                )}
+              </div>
+              <Button size="sm" type="submit" loading={submitting} disabled={applied}>
+                提交申请
+              </Button>
+            </Group>
+          </form>
+        </Card>
+      )}
     </Container>
   );
 }

--- a/src/pages/developer/Info.tsx
+++ b/src/pages/developer/Info.tsx
@@ -146,7 +146,7 @@ const DeveloperInfoContent = () => {
           <Button
             size="sm"
             component="a"
-            href="https://qm.qq.com/q/SfEFsTAAYm"
+            href="https://qm.qq.com/q/Erjj159Ji8"
             target="_blank"
             rel="noreferrer"
             leftSection={<Icon path={mdiQqchat} size={0.8} />}

--- a/src/pages/public/VerifyEmail.tsx
+++ b/src/pages/public/VerifyEmail.tsx
@@ -17,39 +17,52 @@ export default function VerifyEmail() {
     () => new URLSearchParams(pageContext.urlParsed.search).get("token") ?? "",
     [pageContext.urlParsed.search],
   );
-  const lastVerificationToken = useRef<string | null>(null);
-  const verificationRequestId = useRef(0);
+  const verificationAttempt = useRef<{
+    token: string;
+    promise: Promise<{ email_verified: boolean }>;
+  } | null>(null);
   const [state, setState] = useState<VerificationState>(token ? "verifying" : "error");
   const [errorMessage, setErrorMessage] = useState(
     token ? "" : "验证链接缺少必要参数，请返回账号详情重新发送验证邮件。",
   );
-  const { mutate: confirmEmailVerification } = useConfirmEmailVerification();
+  const { mutateAsync: confirmEmailVerification } = useConfirmEmailVerification();
 
   useEffect(() => {
     if (!token) {
-      lastVerificationToken.current = null;
-      verificationRequestId.current += 1;
+      verificationAttempt.current = null;
       setErrorMessage("验证链接缺少必要参数，请返回账号详情重新发送验证邮件。");
       setState("error");
       return;
     }
-    if (Object.is(lastVerificationToken.current, token)) return;
-    lastVerificationToken.current = token;
-    const requestId = ++verificationRequestId.current;
+
+    let attempt = verificationAttempt.current;
+    if (!attempt || !Object.is(attempt.token, token)) {
+      attempt = {
+        token,
+        promise: confirmEmailVerification(token),
+      };
+      verificationAttempt.current = attempt;
+    }
+
+    let active = true;
     setErrorMessage("");
     setState("verifying");
-    confirmEmailVerification(token, {
-      onSuccess: () => {
-        if (requestId !== verificationRequestId.current) return;
+    void attempt.promise.then(
+      () => {
+        if (!active || !Object.is(verificationAttempt.current, attempt)) return;
         setState("verified");
         void queryClient.invalidateQueries({ queryKey: queryKeys.user.profile() });
       },
-      onError: () => {
-        if (requestId !== verificationRequestId.current) return;
+      () => {
+        if (!active || !Object.is(verificationAttempt.current, attempt)) return;
         setErrorMessage("验证链接无效或已过期，请返回账号详情重新发送验证邮件。");
         setState("error");
       },
-    });
+    );
+
+    return () => {
+      active = false;
+    };
   }, [confirmEmailVerification, queryClient, token]);
 
   return (

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -1,40 +1,121 @@
 import { isTokenExpired, isTokenUndefined } from "@/utils/session.ts";
 import { queryClient } from "@/lib/queryClient.ts";
+import { APIError } from "@/utils/errors.ts";
+import { ApiResponse } from "@/types/api";
 
 export const API_URL = import.meta.env.VITE_API_URL;
 
-let refreshPromise: Promise<void> | null = null;
+interface RefreshTokenData {
+  token: string;
+}
 
-async function refreshToken() {
+const REFRESH_RETRY_DELAYS = [300, 1000];
+const TOKEN_REFRESH_BUFFER_MS = 30 * 1000;
+
+let refreshPromise: Promise<RefreshTokenData> | null = null;
+
+const delay = (milliseconds: number) =>
+  new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds));
+
+async function getRefreshError(response: Response): Promise<APIError> {
   try {
-    const response = await fetch(`${API_URL}/user/refresh`, {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("token")}`,
-        "Content-Type": "application/json",
-      },
+    const data = (await response.json()) as Partial<ApiResponse>;
+    return new APIError(data.message || "登录状态刷新失败", {
+      code: data.code,
+      status: response.status,
     });
-
-    if (response.ok) {
-      const data = await response.json();
-      localStorage.setItem("token", data.data.token);
-      queryClient.setQueryData(["user/refresh"], data.data);
-    } else {
-      // 刷新失败，清除过期 token，后续请求将由全局错误处理引导登录
-      localStorage.removeItem("token");
-    }
-  } finally {
-    refreshPromise = null;
+  } catch {
+    return new APIError("登录状态刷新失败", { status: response.status });
   }
 }
 
-async function ensureTokenValid() {
-  if (!isTokenUndefined() && isTokenExpired()) {
-    if (!refreshPromise) {
-      refreshPromise = refreshToken();
+async function requestTokenRefresh(): Promise<RefreshTokenData> {
+  let lastError: APIError | null = null;
+
+  for (let attempt = 0; attempt <= REFRESH_RETRY_DELAYS.length; attempt += 1) {
+    let response: Response;
+
+    try {
+      response = await fetch(`${API_URL}/user/refresh`, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "Content-Type": "application/json",
+        },
+      });
+    } catch {
+      lastError = new APIError("网络连接异常，请稍后重试");
+
+      if (attempt < REFRESH_RETRY_DELAYS.length) {
+        await delay(REFRESH_RETRY_DELAYS[attempt]);
+        continue;
+      }
+
+      throw lastError;
     }
-    await refreshPromise;
+
+    if (!response.ok) {
+      const error = await getRefreshError(response);
+
+      if (response.status === 401 || response.status === 403) {
+        localStorage.removeItem("token");
+        throw error;
+      }
+
+      const canRetry = response.status === 408 || response.status === 429 || response.status >= 500;
+      if (!canRetry || attempt === REFRESH_RETRY_DELAYS.length) {
+        throw error;
+      }
+
+      lastError = error;
+      await delay(REFRESH_RETRY_DELAYS[attempt]);
+      continue;
+    }
+
+    try {
+      const data = (await response.json()) as ApiResponse<RefreshTokenData>;
+      if (!data.success || !data.data?.token) {
+        throw new APIError(data.message || "服务器返回了无效的响应", {
+          code: data.code,
+          status: response.status,
+        });
+      }
+
+      localStorage.setItem("token", data.data.token);
+      queryClient.setQueryData(["user/refresh"], data.data);
+      return data.data;
+    } catch (error) {
+      lastError =
+        error instanceof APIError
+          ? error
+          : new APIError("服务器返回了无效的响应", { status: response.status });
+
+      if (attempt < REFRESH_RETRY_DELAYS.length) {
+        await delay(REFRESH_RETRY_DELAYS[attempt]);
+        continue;
+      }
+
+      throw lastError;
+    }
+  }
+
+  throw lastError || new APIError("登录状态刷新失败");
+}
+
+export function refreshAccessToken(): Promise<RefreshTokenData> {
+  if (!refreshPromise) {
+    refreshPromise = requestTokenRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+}
+
+async function ensureTokenValid() {
+  if (!isTokenUndefined() && isTokenExpired(TOKEN_REFRESH_BUFFER_MS)) {
+    await refreshAccessToken();
   }
 }
 

--- a/src/utils/emailVerification.ts
+++ b/src/utils/emailVerification.ts
@@ -1,0 +1,4 @@
+export function emailVerificationSentMessage(expiresIn?: number): string {
+  if (!expiresIn || expiresIn <= 0) return "请尽快前往邮箱完成验证。";
+  return `请在 ${Math.ceil(expiresIn / 60)} 分钟内前往邮箱完成验证。`;
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -31,7 +31,7 @@ export const getSentryUser = () => {
   };
 };
 
-export const isTokenExpired = () => {
+export const isTokenExpired = (bufferMs = 0) => {
   if (!isBrowser()) return true;
   const token = localStorage.getItem("token");
   if (!token) {
@@ -47,7 +47,7 @@ export const isTokenExpired = () => {
       return true;
     }
 
-    return currentTime > expirationTime;
+    return currentTime + bufferMs > expirationTime;
   } catch (error) {
     return true;
   }


### PR DESCRIPTION
## Summary
- guide unverified users through email verification before showing the developer application form
- poll verification status after sending mail, pausing in the background and falling back to a manual check
- make the verification result page resilient to React Strict Mode effect remounts
- skip score comment queries until a concrete score is available
- document the verified-email requirement

## Backend
- https://github.com/Lxns-Network/maimai-prober/pull/83

## Testing
- targeted ESLint with zero warnings
- `yarn tsc --noEmit`
- `yarn build`
