### PR TITLE
feat(settings): add runtime limit controls

### DIFF
--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -152,6 +152,13 @@ export const SystemSettingsSection = () => {
 
   const taskSettingsConfig: SettingProps[] = [
     {
+      key: "worker.remote_only",
+      title: "仅使用远程工作节点",
+      description: "启用后将禁用本地工作节点，所有任务将由远程工作节点处理。",
+      optionType: "switch",
+      defaultValue: SETTINGS_DEFAULTS["worker.remote_only"] as boolean,
+    },
+    {
       key: "proxy.max_pending_tasks",
       title: "排队任务上限",
       description: "达到上限后将暂时拒绝新的任务。",
@@ -174,16 +181,6 @@ export const SystemSettingsSection = () => {
       optionType: "select",
       options: EXPIRE_OPTIONS,
       defaultValue: String(SETTINGS_DEFAULTS["worker.task_expire"]),
-    },
-  ];
-
-  const workerSettingsConfig: SettingProps[] = [
-    {
-      key: "worker.remote_only",
-      title: "仅使用远程工作节点",
-      description: "启用后将禁用本地工作节点，所有任务将由远程工作节点处理。",
-      optionType: "switch",
-      defaultValue: SETTINGS_DEFAULTS["worker.remote_only"] as boolean,
     },
   ];
 
@@ -216,19 +213,9 @@ export const SystemSettingsSection = () => {
           任务调度
         </Text>
         <Text fz="xs" c="dimmed" mt={3} mb="lg">
-          配置任务队列容量与任务生命周期
+          配置任务队列与任务执行方式
         </Text>
         <SettingList data={taskSettingsConfig} value={valueMap} onChange={handleChange} />
-      </Card>
-      <Card withBorder radius="md" className={classes.card} mb="md">
-        <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />
-        <Text fz="lg" fw={700}>
-          工作节点
-        </Text>
-        <Text fz="xs" c="dimmed" mt={3} mb="lg">
-          配置本地与远程工作节点的运行模式
-        </Text>
-        <SettingList data={workerSettingsConfig} value={valueMap} onChange={handleChange} />
       </Card>
       <Card withBorder radius="md" className={classes.card} mb="md">
         <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Card, Text, LoadingOverlay } from "@mantine/core";
 import classes from "@/pages/Page.module.css";
 import { SettingList, SettingProps } from "@/components/Settings/SettingList.tsx";
@@ -10,10 +10,20 @@ import { RecalculateSection } from "../recalculate/RecalculateSection.tsx";
 const SETTINGS_DEFAULTS: Record<string, unknown> = {
   "proxy.maintenance.maimai": false,
   "proxy.maintenance.chunithm": false,
+  "proxy.max_pending_tasks": 200,
   "worker.remote_only": false,
   "worker.task_timeout": 900,
   "worker.task_expire": 86400,
+  "oauth.dynamic_client_retention": 2592000,
 };
+
+const PENDING_TASK_OPTIONS = [
+  { value: "50", label: "50 个" },
+  { value: "100", label: "100 个" },
+  { value: "200", label: "200 个" },
+  { value: "500", label: "500 个" },
+  { value: "1000", label: "1000 个" },
+];
 
 const TIMEOUT_OPTIONS = [
   { value: "300", label: "5 分钟" },
@@ -33,11 +43,18 @@ const EXPIRE_OPTIONS = [
   { value: "604800", label: "7 天" },
 ];
 
+const DYNAMIC_CLIENT_RETENTION_OPTIONS = [
+  { value: "604800", label: "7 天" },
+  { value: "1209600", label: "14 天" },
+  { value: "2592000", label: "30 天" },
+  { value: "7776000", label: "90 天" },
+];
+
 export const SystemSettingsSection = () => {
   const [settings, setSettings] = useState<Record<string, unknown>>({});
   const [fetching, setFetching] = useState(true);
 
-  const fetchSettings = async () => {
+  const fetchSettings = useCallback(async () => {
     setFetching(true);
     try {
       const res = await getSystemSettings();
@@ -51,17 +68,22 @@ export const SystemSettingsSection = () => {
     } finally {
       setFetching(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    fetchSettings();
-  }, []);
+    void fetchSettings();
+  }, [fetchSettings]);
 
   const handleChange = async (key: string, value: string | boolean | string[] | null) => {
     let parsedValue: unknown = value;
 
     // Convert string numbers to actual numbers for numeric settings
-    if (key === "worker.task_timeout" || key === "worker.task_expire") {
+    if (
+      key === "worker.task_timeout" ||
+      key === "worker.task_expire" ||
+      key === "proxy.max_pending_tasks" ||
+      key === "oauth.dynamic_client_retention"
+    ) {
       parsedValue = Number(value);
     }
 
@@ -91,7 +113,12 @@ export const SystemSettingsSection = () => {
   for (const key of Object.keys(SETTINGS_DEFAULTS)) {
     const val = key in settings ? settings[key] : SETTINGS_DEFAULTS[key];
     // Convert numeric values to strings for select components
-    if (key === "worker.task_timeout" || key === "worker.task_expire") {
+    if (
+      key === "worker.task_timeout" ||
+      key === "worker.task_expire" ||
+      key === "proxy.max_pending_tasks" ||
+      key === "oauth.dynamic_client_retention"
+    ) {
       valueMap[key] = String(val);
     } else {
       valueMap[key] = val;
@@ -121,6 +148,14 @@ export const SystemSettingsSection = () => {
         },
       ],
     },
+    {
+      key: "proxy.max_pending_tasks",
+      title: "排队任务上限",
+      description: "达到上限后将暂时拒绝新的代理任务。",
+      optionType: "select",
+      options: PENDING_TASK_OPTIONS,
+      defaultValue: String(SETTINGS_DEFAULTS["proxy.max_pending_tasks"]),
+    },
   ];
 
   const workerSettingsConfig: SettingProps[] = [
@@ -149,6 +184,17 @@ export const SystemSettingsSection = () => {
     },
   ];
 
+  const oauthSettingsConfig: SettingProps[] = [
+    {
+      key: "oauth.dynamic_client_retention",
+      title: "动态客户端保留时间",
+      description: "未使用的动态客户端超过此时间后将自动清理。",
+      optionType: "select",
+      options: DYNAMIC_CLIENT_RETENTION_OPTIONS,
+      defaultValue: String(SETTINGS_DEFAULTS["oauth.dynamic_client_retention"]),
+    },
+  ];
+
   return (
     <div>
       <Card withBorder radius="md" className={classes.card} mb="md">
@@ -160,6 +206,16 @@ export const SystemSettingsSection = () => {
           控制各游戏的代理服务与数据爬取
         </Text>
         <SettingList data={proxySettingsConfig} value={valueMap} onChange={handleChange} />
+      </Card>
+      <Card withBorder radius="md" className={classes.card} mb="md">
+        <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />
+        <Text fz="lg" fw={700}>
+          OAuth
+        </Text>
+        <Text fz="xs" c="dimmed" mt={3} mb="lg">
+          配置 OAuth 动态客户端的生命周期
+        </Text>
+        <SettingList data={oauthSettingsConfig} value={valueMap} onChange={handleChange} />
       </Card>
       <Card withBorder radius="md" className={classes.card} mb="md">
         <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -10,7 +10,7 @@ import { RecalculateSection } from "../recalculate/RecalculateSection.tsx";
 const SETTINGS_DEFAULTS: Record<string, unknown> = {
   "proxy.maintenance.maimai": false,
   "proxy.maintenance.chunithm": false,
-  "proxy.max_pending_tasks": 200,
+  "worker.max_pending_tasks": 200,
   "worker.remote_only": false,
   "worker.task_timeout": 900,
   "worker.task_expire": 86400,
@@ -81,7 +81,7 @@ export const SystemSettingsSection = () => {
     if (
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
-      key === "proxy.max_pending_tasks" ||
+      key === "worker.max_pending_tasks" ||
       key === "oauth.dynamic_client_retention"
     ) {
       parsedValue = Number(value);
@@ -116,7 +116,7 @@ export const SystemSettingsSection = () => {
     if (
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
-      key === "proxy.max_pending_tasks" ||
+      key === "worker.max_pending_tasks" ||
       key === "oauth.dynamic_client_retention"
     ) {
       valueMap[key] = String(val);
@@ -159,12 +159,12 @@ export const SystemSettingsSection = () => {
       defaultValue: SETTINGS_DEFAULTS["worker.remote_only"] as boolean,
     },
     {
-      key: "proxy.max_pending_tasks",
+      key: "worker.max_pending_tasks",
       title: "排队任务上限",
       description: "达到上限后将暂时拒绝新的任务。",
       optionType: "select",
       options: PENDING_TASK_OPTIONS,
-      defaultValue: String(SETTINGS_DEFAULTS["proxy.max_pending_tasks"]),
+      defaultValue: String(SETTINGS_DEFAULTS["worker.max_pending_tasks"]),
     },
     {
       key: "worker.task_timeout",

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -148,23 +148,16 @@ export const SystemSettingsSection = () => {
         },
       ],
     },
+  ];
+
+  const taskSettingsConfig: SettingProps[] = [
     {
       key: "proxy.max_pending_tasks",
       title: "排队任务上限",
-      description: "达到上限后将暂时拒绝新的代理任务。",
+      description: "达到上限后将暂时拒绝新的任务。",
       optionType: "select",
       options: PENDING_TASK_OPTIONS,
       defaultValue: String(SETTINGS_DEFAULTS["proxy.max_pending_tasks"]),
-    },
-  ];
-
-  const workerSettingsConfig: SettingProps[] = [
-    {
-      key: "worker.remote_only",
-      title: "仅使用远程工作节点",
-      description: "启用后将禁用本地工作节点，所有任务将由远程工作节点处理。",
-      optionType: "switch",
-      defaultValue: SETTINGS_DEFAULTS["worker.remote_only"] as boolean,
     },
     {
       key: "worker.task_timeout",
@@ -177,10 +170,20 @@ export const SystemSettingsSection = () => {
     {
       key: "worker.task_expire",
       title: "任务过期时间",
-      description: "已完成或失败的任务超过此时间后将被自动删除。",
+      description: "已完成或失败的任务超过此时间后将自动删除。",
       optionType: "select",
       options: EXPIRE_OPTIONS,
       defaultValue: String(SETTINGS_DEFAULTS["worker.task_expire"]),
+    },
+  ];
+
+  const workerSettingsConfig: SettingProps[] = [
+    {
+      key: "worker.remote_only",
+      title: "仅使用远程工作节点",
+      description: "启用后将禁用本地工作节点，所有任务将由远程工作节点处理。",
+      optionType: "switch",
+      defaultValue: SETTINGS_DEFAULTS["worker.remote_only"] as boolean,
     },
   ];
 
@@ -210,12 +213,12 @@ export const SystemSettingsSection = () => {
       <Card withBorder radius="md" className={classes.card} mb="md">
         <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />
         <Text fz="lg" fw={700}>
-          OAuth
+          任务调度
         </Text>
         <Text fz="xs" c="dimmed" mt={3} mb="lg">
-          配置 OAuth 动态客户端的生命周期
+          配置任务队列容量与任务生命周期
         </Text>
-        <SettingList data={oauthSettingsConfig} value={valueMap} onChange={handleChange} />
+        <SettingList data={taskSettingsConfig} value={valueMap} onChange={handleChange} />
       </Card>
       <Card withBorder radius="md" className={classes.card} mb="md">
         <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />
@@ -223,9 +226,19 @@ export const SystemSettingsSection = () => {
           工作节点
         </Text>
         <Text fz="xs" c="dimmed" mt={3} mb="lg">
-          配置工作节点的运行模式与任务参数
+          配置本地与远程工作节点的运行模式
         </Text>
         <SettingList data={workerSettingsConfig} value={valueMap} onChange={handleChange} />
+      </Card>
+      <Card withBorder radius="md" className={classes.card} mb="md">
+        <LoadingOverlay visible={fetching} overlayProps={{ radius: "sm", blur: 2 }} zIndex={1} />
+        <Text fz="lg" fw={700}>
+          OAuth
+        </Text>
+        <Text fz="xs" c="dimmed" mt={3} mb="lg">
+          配置 OAuth 动态客户端的生命周期
+        </Text>
+        <SettingList data={oauthSettingsConfig} value={valueMap} onChange={handleChange} />
       </Card>
       <RecalculateSection />
     </div>


### PR DESCRIPTION
## Summary
- move the runtime queue limit and dynamic OAuth client retention to the existing `system_settings` format
- keep safe defaults and validation in the backend when settings are missing or invalid
- add admin controls for task scheduling and the existing system-settings UI

## Settings
- `worker.max_pending_tasks` (default `200`, allowed `1`–`10000`)
- `oauth.dynamic_client_retention` (default `2592000` seconds)

## Validation
- `yarn build`
- targeted ESLint check for the changed settings page

Backend implementation: Lxns-Network/maimai-prober#84
