### PR TITLE
feat(settings): add dynamic client quota

### DIFF
--- a/public/docs/oauth-guide.md
+++ b/public/docs/oauth-guide.md
@@ -332,9 +332,11 @@ from flask import Flask, request, session
 import requests
 import urllib.parse
 import secrets
+import os
 
 app = Flask(__name__)
-app.secret_key = "replace-with-a-random-secret"
+# 使用 secrets.token_hex(32) 生成后写入环境变量
+app.secret_key = os.environ["FLASK_SECRET_KEY"]
 
 # 应用信息
 CLIENT_ID = "e07f2ae3-795b-4368-b55f-5f27b0b3eae0"
@@ -439,9 +441,11 @@ import urllib.parse
 import secrets
 import hashlib
 import base64
+import os
 
 app = Flask(__name__)
-app.secret_key = "replace-with-a-random-secret"
+# 使用 secrets.token_hex(32) 生成后写入环境变量
+app.secret_key = os.environ["FLASK_SECRET_KEY"]
 
 # 应用信息（公共客户端，无 secret）
 CLIENT_ID = "e07f2ae3-795b-4368-b55f-5f27b0b3eae0"

--- a/public/docs/oauth-guide.md
+++ b/public/docs/oauth-guide.md
@@ -68,16 +68,16 @@ https://maimai.lxns.net/oauth/authorize?response_type=code&client_id=[应用 ID]
 
 常用参数如下：
 
-| 参数名                  | 必填      | 说明                                                   |
-| ----------------------- | --------- | ------------------------------------------------------ |
-| `response_type`         | 是        | 固定为 `code`                                          |
-| `client_id`             | 是        | 创建应用后获得的应用 ID                                |
-| `redirect_uri`          | 是        | 本次授权使用的回调地址，必须与已登记地址完全一致       |
-| `scope`                 | 是        | 以空格分隔的权限列表                                   |
-| `state`                 | 推荐      | 用于关联请求和回调，并防止跨站请求伪造                 |
-| `nonce`                 | OIDC 推荐 | 绑定授权请求和 ID Token，防止重放攻击；最长 255 个字符 |
-| `code_challenge`        | 使用 PKCE 时必填 | 由 `code_verifier` 计算得到的挑战值              |
-| `code_challenge_method` | 使用 PKCE 时必填 | 固定为 `S256`                                    |
+| 参数名                  | 必填             | 说明                                                   |
+| ----------------------- | ---------------- | ------------------------------------------------------ |
+| `response_type`         | 是               | 固定为 `code`                                          |
+| `client_id`             | 是               | 创建应用后获得的应用 ID                                |
+| `redirect_uri`          | 是               | 本次授权使用的回调地址，必须与已登记地址完全一致       |
+| `scope`                 | 是               | 以空格分隔的权限列表                                   |
+| `state`                 | 推荐             | 用于关联请求和回调，并防止跨站请求伪造                 |
+| `nonce`                 | OIDC 推荐        | 绑定授权请求和 ID Token，防止重放攻击；最长 255 个字符 |
+| `code_challenge`        | 使用 PKCE 时必填 | 由 `code_verifier` 计算得到的挑战值                    |
+| `code_challenge_method` | 使用 PKCE 时必填 | 固定为 `S256`                                          |
 
 仅调用查分器 API 的示例：
 
@@ -208,12 +208,12 @@ POST /api/v0/oauth/token
 
 #### 请求参数
 
-| 参数名          | 类型   | 说明                             |
-| --------------- | ------ | -------------------------------- |
-| `client_id`     | string | 应用 ID                          |
+| 参数名          | 类型   | 说明                                     |
+| --------------- | ------ | ---------------------------------------- |
+| `client_id`     | string | 应用 ID                                  |
 | `client_secret` | string | 机密客户端的应用密钥；使用 PKCE 时可省略 |
-| `grant_type`    | string | 授权类型，固定为 `refresh_token` |
-| `refresh_token` | string | 从上一步获取的刷新令牌           |
+| `grant_type`    | string | 授权类型，固定为 `refresh_token`         |
+| `refresh_token` | string | 从上一步获取的刷新令牌                   |
 
 #### 请求示例
 
@@ -412,7 +412,7 @@ PKCE 通过在授权请求中添加一个随机生成的 `code_verifier` 和 `co
 | `grant_type`    | string | 授权类型，固定为 `authorization_code`        |
 | `code`          | string | 从回调地址获取的授权码                       |
 | `redirect_uri`  | string | 必须与授权请求及某个已登记的回调地址完全一致 |
-| `code_verifier` | string | 生成授权请求时保存的原始验证字符串             |
+| `code_verifier` | string | 生成授权请求时保存的原始验证字符串           |
 
 #### 请求示例
 

--- a/public/docs/oauth-guide.md
+++ b/public/docs/oauth-guide.md
@@ -32,7 +32,7 @@
 - **回调地址**：授权完成后用户将被重定向到请求指定的地址。每个应用最多可以登记 10 个回调地址。
 - **应用权限**：根据用途选择 API 授权或 OpenID Connect 身份认证所需的权限。
 
-授权请求中的 `redirect_uri` 必须与已登记的某个回调地址完全一致。Web 应用应使用 HTTPS；本地开发可以使用 `localhost`、`127.0.0.1` 或 `[::1]` 的 HTTP 地址，移动端和桌面端应用也可以使用自定义协议地址。
+授权请求中的 `redirect_uri` 必须与已登记的某个回调地址完全一致。Web 应用应使用 HTTPS；本地开发可以使用 `localhost`、`127.0.0.1` 或 `[::1]` 的 HTTP 地址。
 
 ::: info 提示
 如果你没有回调地址，你可以勾选“无回调地址”，这将在授权成功后直接返回授权码，而不是重定向到回调地址。
@@ -76,8 +76,8 @@ https://maimai.lxns.net/oauth/authorize?response_type=code&client_id=[应用 ID]
 | `scope`                 | 是        | 以空格分隔的权限列表                                   |
 | `state`                 | 推荐      | 用于关联请求和回调，并防止跨站请求伪造                 |
 | `nonce`                 | OIDC 推荐 | 绑定授权请求和 ID Token，防止重放攻击；最长 255 个字符 |
-| `code_challenge`        | PKCE 必填 | 由 `code_verifier` 计算得到的挑战值                    |
-| `code_challenge_method` | PKCE 必填 | 推荐并应使用 `S256`                                    |
+| `code_challenge`        | 使用 PKCE 时必填 | 由 `code_verifier` 计算得到的挑战值              |
+| `code_challenge_method` | 使用 PKCE 时必填 | 固定为 `S256`                                    |
 
 仅调用查分器 API 的示例：
 
@@ -96,7 +96,7 @@ https://maimai.lxns.net/oauth/authorize?response_type=code&client_id=[应用 ID]
 :::
 
 ::: info 提示
-如果你是公共客户端，无法存储并使用 `client_secret`，可以使用 [PKCE](#pkce)（Proof Key for Code Exchange） 来增强安全性。
+公共客户端应使用 [PKCE](#pkce)（Proof Key for Code Exchange）。授权请求带有 `code_challenge` 时，兑换授权码必须提交对应的 `code_verifier`；`client_secret` 作为额外的客户端认证信息进行校验。
 :::
 
 ### 3. 用户授权
@@ -132,8 +132,8 @@ POST /api/v0/oauth/token
 | `scope`         | string  | 授权范围，表示应用可以访问的权限                |
 | `id_token`      | string  | OIDC ID Token，仅在授权范围包含 `openid` 时返回 |
 
-::: danger 破坏性变更
-访问令牌响应的字段现已位于响应**顶层**（符合 OAuth 2.0 标准）。为兼容旧版集成，`data` 包装（即 `data.access_token`）暂时保留，但**已废弃，并将在未来版本中移除**。请尽快改为从响应顶层直接读取 `access_token` 等字段。
+::: info 响应格式
+访问令牌响应字段位于响应**顶层**，请读取 `access_token`、`token_type`、`expires_in`、`refresh_token` 和 `scope` 等字段。
 :::
 
 ::: info 提示
@@ -141,7 +141,7 @@ POST /api/v0/oauth/token
 :::
 
 ::: warning 注意
-访问令牌有效期为 15 分钟，过期后需使用刷新令牌重新获取。系统将返回新的访问令牌，同时刷新令牌保持有效（除非手动撤销或超过 30 天有效期）。请确保安全存储刷新令牌，以便持续获取新的访问令牌。
+访问令牌有效期为 15 分钟。刷新令牌有效期为 30 天，每次成功刷新后响应都会包含新的刷新令牌，原令牌立即失效。请确保安全存储刷新令牌，并在成功响应后保存新令牌。
 :::
 
 #### 响应示例
@@ -203,7 +203,7 @@ POST /api/v0/oauth/token
 ```
 
 ::: warning 注意
-刷新令牌有效期为 30 天。每次使用刷新令牌获取新的访问令牌时，系统将同时颁发一个新的刷新令牌，**旧令牌自动失效**。
+刷新令牌有效期为 30 天。每次成功使用刷新令牌后，响应都会包含新的刷新令牌，原令牌立即失效；重复提交已失效的令牌会返回 `invalid_grant`。
 :::
 
 #### 请求参数
@@ -211,7 +211,7 @@ POST /api/v0/oauth/token
 | 参数名          | 类型   | 说明                             |
 | --------------- | ------ | -------------------------------- |
 | `client_id`     | string | 应用 ID                          |
-| `client_secret` | string | 应用密钥，PKCE 不需要此参数      |
+| `client_secret` | string | 机密客户端的应用密钥；使用 PKCE 时可省略 |
 | `grant_type`    | string | 授权类型，固定为 `refresh_token` |
 | `refresh_token` | string | 从上一步获取的刷新令牌           |
 
@@ -295,13 +295,11 @@ UserInfo 端点要求访问令牌包含 `openid`。`profile` 和 `email` 仅控�
 
 ## 访问令牌请求方式
 
-获取访问令牌有两种方式：**应用密钥**和**PKCE**（Proof Key for Code Exchange）。这两种方式适用于不同类型的客户端。
-
-你可以选择其中一种方式来获取访问令牌，也可以根据你的应用类型和安全需求结合使用。
+授权码兑换支持**应用密钥**和 **PKCE**（Proof Key for Code Exchange）。公共客户端使用 PKCE，机密客户端使用应用密钥。授权请求带有 `code_challenge` 时，兑换授权码必须提交对应的 `code_verifier`；请求同时带有 `client_secret` 时，服务器会校验两项。未使用 PKCE 时，兑换授权码必须提交有效的 `client_secret`。
 
 ### 应用密钥
 
-如果你的应用是机密客户端（如服务器端应用），你可以使用应用密钥认证来获取访问令牌。此方式需要在请求中提供 `client_secret`。
+机密客户端（如服务器端应用）可以使用应用密钥认证来获取访问令牌。此方式需要在请求中提供有效的 `client_secret`。
 
 #### 请求参数
 
@@ -330,11 +328,13 @@ UserInfo 端点要求访问令牌包含 `openid`。`profile` 和 `email` 仅控�
 以下是一个使用应用密钥获取访问令牌的示例代码，演示如何处理 OAuth 授权流程：
 
 ```python
-from flask import Flask, request
+from flask import Flask, request, session
 import requests
 import urllib.parse
+import secrets
 
 app = Flask(__name__)
+app.secret_key = "replace-with-a-random-secret"
 
 # 应用信息
 CLIENT_ID = "e07f2ae3-795b-4368-b55f-5f27b0b3eae0"
@@ -349,12 +349,14 @@ PLAYER_API_URL = "https://maimai.lxns.net/api/v0/user/maimai/player"
 @app.route("/")
 def home():
     scope = ["read_player"]
+    state = secrets.token_urlsafe(16)
+    session["oauth_state"] = state
     query = {
         "response_type": "code",
         "client_id": CLIENT_ID,
         "redirect_uri": REDIRECT_URI,
         "scope": " ".join(scope),
-        "state": "test"  # 可选，如果不需要可以注释掉这一行
+        "state": state
     }
     url = f"{AUTHORIZE_URL}?{urllib.parse.urlencode(query)}"
     return f'<a href="{url}">点击授权</a>'
@@ -364,6 +366,8 @@ def callback():
     code = request.args.get("code")
     if not code:
         return "授权失败，未获取到授权码", 400
+    if request.args.get("state") != session.pop("oauth_state", None):
+        return "授权失败，state 校验未通过", 400
 
     # 获取访问码
     resp = requests.post(TOKEN_URL, data={
@@ -406,7 +410,7 @@ PKCE 通过在授权请求中添加一个随机生成的 `code_verifier` 和 `co
 | `grant_type`    | string | 授权类型，固定为 `authorization_code`        |
 | `code`          | string | 从回调地址获取的授权码                       |
 | `redirect_uri`  | string | 必须与授权请求及某个已登记的回调地址完全一致 |
-| `code_verifier` | string | PKCE 验证码                                  |
+| `code_verifier` | string | 生成授权请求时保存的原始验证字符串             |
 
 #### 请求示例
 
@@ -425,11 +429,11 @@ PKCE 通过在授权请求中添加一个随机生成的 `code_verifier` 和 `co
 以下是一个使用 PKCE 的示例代码，演示如何生成 `code_verifier` 和 `code_challenge`，并在授权请求中使用它们：
 
 ::: warning 注意
-示例中通过 `state` 参数传递 `code_verifier` 仅用作示范，实际应用中不建议将其暴露在 URL 中。
+请在用户会话或其他受保护的服务端存储中保存 `code_verifier`，不要将其放入 `state` 或其他 URL 参数。
 :::
 
 ```python
-from flask import Flask, request
+from flask import Flask, request, session
 import requests
 import urllib.parse
 import secrets
@@ -437,6 +441,7 @@ import hashlib
 import base64
 
 app = Flask(__name__)
+app.secret_key = "replace-with-a-random-secret"
 
 # 应用信息（公共客户端，无 secret）
 CLIENT_ID = "e07f2ae3-795b-4368-b55f-5f27b0b3eae0"
@@ -462,6 +467,9 @@ def home():
     # 生成随机 code_verifier
     code_verifier = generate_code_verifier()
     code_challenge = generate_code_challenge(code_verifier)
+    state = secrets.token_urlsafe(16)
+    session["oauth_state"] = state
+    session["code_verifier"] = code_verifier
 
     query = {
         "response_type": "code",
@@ -470,7 +478,7 @@ def home():
         "scope": " ".join(scope),
         "code_challenge": code_challenge,
         "code_challenge_method": "S256",
-        "state": code_verifier
+        "state": state
     }
     url = f"{AUTHORIZE_URL}?{urllib.parse.urlencode(query)}"
     return f'<a href="{url}">点击授权</a>'
@@ -480,6 +488,11 @@ def callback():
     code = request.args.get("code")
     if not code:
         return "授权失败，未获取到授权码", 400
+    if request.args.get("state") != session.pop("oauth_state", None):
+        return "授权失败，state 校验未通过", 400
+    code_verifier = session.pop("code_verifier", None)
+    if not code_verifier:
+        return "授权失败，code_verifier 不存在", 400
 
     # 用 code_verifier 换 token
     resp = requests.post(TOKEN_URL, data={
@@ -487,7 +500,7 @@ def callback():
         "code": code,
         "client_id": CLIENT_ID,
         "redirect_uri": REDIRECT_URI,
-        "code_verifier": request.args.get("state")
+        "code_verifier": code_verifier
     })
     token_data = resp.json()
     access_token = token_data["access_token"]

--- a/src/components/Settings/SettingList.tsx
+++ b/src/components/Settings/SettingList.tsx
@@ -19,6 +19,8 @@ interface OptionProps {
   label: string;
 }
 
+type OptionRenderer = (input: { option: OptionProps; checked?: boolean }) => React.ReactNode;
+
 export interface SettingProps {
   key: string;
   title: string;
@@ -29,6 +31,7 @@ export interface SettingProps {
   defaultValue?: string | boolean | string[]; // string[] 选项类型为 'multi-select' 时需要
   settings?: SettingProps[]; // 选项类型为 'group' 时需要
   options?: OptionProps[]; // 选项类型为 'select' 或 'multi-select' 时需要
+  renderOption?: OptionRenderer; // 自定义下拉选项渲染
   onChange?: (value: string | boolean | string[] | null) => void; // 选项更改时的回调函数
   onClick?: () => void; // 选项类型为 'button' 时需要
   render?: () => React.ReactNode; // 选项类型为 'custom' 时需要
@@ -106,6 +109,7 @@ const Setting = ({
                   <Select
                     variant="filled"
                     data={data.options || []}
+                    renderOption={data.renderOption}
                     value={
                       value && data.key in value
                         ? (value[data.key] as string)
@@ -125,6 +129,7 @@ const Setting = ({
                   <MultiSelect
                     variant="filled"
                     data={data.options || []}
+                    renderOption={data.renderOption}
                     placeholder={data.placeholder}
                     value={
                       value && data.key in value

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Card, Text, LoadingOverlay } from "@mantine/core";
+import { Card, Text, LoadingOverlay, NumberFormatter } from "@mantine/core";
 import classes from "@/pages/Page.module.css";
 import { SettingList, SettingProps } from "@/components/Settings/SettingList.tsx";
 import { getSystemSettings, updateSystemSettings } from "@/utils/api/admin.ts";
@@ -18,13 +18,21 @@ const SETTINGS_DEFAULTS: Record<string, unknown> = {
   "oauth.dynamic_client_max_count": 10000,
 };
 
-const PENDING_TASK_OPTIONS = [
-  { value: "50", label: "50 个" },
-  { value: "100", label: "100 个" },
-  { value: "200", label: "200 个" },
-  { value: "500", label: "500 个" },
-  { value: "1000", label: "1000 个" },
-];
+const countNumberFormatter = new Intl.NumberFormat("en-US");
+
+const createCountOptions = (values: number[]) =>
+  values.map((value) => ({
+    value: String(value),
+    label: `${countNumberFormatter.format(value)} 个`,
+  }));
+
+const renderCountOption = ({ option }: { option: { value: string; label: string } }) => (
+  <>
+    <NumberFormatter value={option.value} thousandSeparator /> 个
+  </>
+);
+
+const PENDING_TASK_OPTIONS = createCountOptions([50, 100, 200, 500, 1000]);
 
 const TIMEOUT_OPTIONS = [
   { value: "300", label: "5 分钟" },
@@ -51,14 +59,9 @@ const DYNAMIC_CLIENT_RETENTION_OPTIONS = [
   { value: "7776000", label: "90 天" },
 ];
 
-const DYNAMIC_CLIENT_MAX_COUNT_OPTIONS = [
-  { value: "1000", label: "1,000 个" },
-  { value: "5000", label: "5,000 个" },
-  { value: "10000", label: "10,000 个" },
-  { value: "25000", label: "25,000 个" },
-  { value: "50000", label: "50,000 个" },
-  { value: "100000", label: "100,000 个" },
-];
+const DYNAMIC_CLIENT_MAX_COUNT_OPTIONS = createCountOptions([
+  1000, 5000, 10000, 25000, 50000, 100000,
+]);
 
 export const SystemSettingsSection = () => {
   const [settings, setSettings] = useState<Record<string, unknown>>({});
@@ -176,6 +179,7 @@ export const SystemSettingsSection = () => {
       description: "达到上限后将暂时拒绝新的任务。",
       optionType: "select",
       options: PENDING_TASK_OPTIONS,
+      renderOption: renderCountOption,
       defaultValue: String(SETTINGS_DEFAULTS["worker.max_pending_tasks"]),
     },
     {
@@ -211,6 +215,7 @@ export const SystemSettingsSection = () => {
       description: "达到上限后将暂时拒绝新的动态客户端注册。",
       optionType: "select",
       options: DYNAMIC_CLIENT_MAX_COUNT_OPTIONS,
+      renderOption: renderCountOption,
       defaultValue: String(SETTINGS_DEFAULTS["oauth.dynamic_client_max_count"]),
     },
   ];

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -15,6 +15,7 @@ const SETTINGS_DEFAULTS: Record<string, unknown> = {
   "worker.task_timeout": 900,
   "worker.task_expire": 86400,
   "oauth.dynamic_client_retention": 2592000,
+  "oauth.dynamic_client_max_count": 10000,
 };
 
 const PENDING_TASK_OPTIONS = [
@@ -50,6 +51,15 @@ const DYNAMIC_CLIENT_RETENTION_OPTIONS = [
   { value: "7776000", label: "90 天" },
 ];
 
+const DYNAMIC_CLIENT_MAX_COUNT_OPTIONS = [
+  { value: "1000", label: "1,000 个" },
+  { value: "5000", label: "5,000 个" },
+  { value: "10000", label: "10,000 个" },
+  { value: "25000", label: "25,000 个" },
+  { value: "50000", label: "50,000 个" },
+  { value: "100000", label: "100,000 个" },
+];
+
 export const SystemSettingsSection = () => {
   const [settings, setSettings] = useState<Record<string, unknown>>({});
   const [fetching, setFetching] = useState(true);
@@ -82,7 +92,8 @@ export const SystemSettingsSection = () => {
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
       key === "worker.max_pending_tasks" ||
-      key === "oauth.dynamic_client_retention"
+      key === "oauth.dynamic_client_retention" ||
+      key === "oauth.dynamic_client_max_count"
     ) {
       parsedValue = Number(value);
     }
@@ -117,7 +128,8 @@ export const SystemSettingsSection = () => {
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
       key === "worker.max_pending_tasks" ||
-      key === "oauth.dynamic_client_retention"
+      key === "oauth.dynamic_client_retention" ||
+      key === "oauth.dynamic_client_max_count"
     ) {
       valueMap[key] = String(val);
     } else {
@@ -193,6 +205,14 @@ export const SystemSettingsSection = () => {
       options: DYNAMIC_CLIENT_RETENTION_OPTIONS,
       defaultValue: String(SETTINGS_DEFAULTS["oauth.dynamic_client_retention"]),
     },
+    {
+      key: "oauth.dynamic_client_max_count",
+      title: "动态客户端数量上限",
+      description: "达到上限后将暂时拒绝新的动态客户端注册。",
+      optionType: "select",
+      options: DYNAMIC_CLIENT_MAX_COUNT_OPTIONS,
+      defaultValue: String(SETTINGS_DEFAULTS["oauth.dynamic_client_max_count"]),
+    },
   ];
 
   return (
@@ -223,7 +243,7 @@ export const SystemSettingsSection = () => {
           OAuth
         </Text>
         <Text fz="xs" c="dimmed" mt={3} mb="lg">
-          配置 OAuth 动态客户端的生命周期
+          配置 OAuth 动态客户端的生命周期与数量上限
         </Text>
         <SettingList data={oauthSettingsConfig} value={valueMap} onChange={handleChange} />
       </Card>

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -95,18 +95,18 @@ export const SystemSettingsSection = () => {
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
       key === "worker.max_pending_tasks" ||
-		key === "oauth.dynamic_client_retention" ||
-		key === "oauth.dynamic_client_max_count"
-	) {
-		if (typeof value !== "string" || value.trim() === "") {
-			return;
-		}
-		const numericValue = Number(value);
-		if (!Number.isFinite(numericValue)) {
-			return;
-		}
-		parsedValue = numericValue;
-	}
+      key === "oauth.dynamic_client_retention" ||
+      key === "oauth.dynamic_client_max_count"
+    ) {
+      if (typeof value !== "string" || value.trim() === "") {
+        return;
+      }
+      const numericValue = Number(value);
+      if (!Number.isFinite(numericValue)) {
+        return;
+      }
+      parsedValue = numericValue;
+    }
 
     try {
       const res = await updateSystemSettings({ [key]: parsedValue });

--- a/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
+++ b/src/pages/admin/Settings/settings/SystemSettingsSection.tsx
@@ -95,11 +95,18 @@ export const SystemSettingsSection = () => {
       key === "worker.task_timeout" ||
       key === "worker.task_expire" ||
       key === "worker.max_pending_tasks" ||
-      key === "oauth.dynamic_client_retention" ||
-      key === "oauth.dynamic_client_max_count"
-    ) {
-      parsedValue = Number(value);
-    }
+		key === "oauth.dynamic_client_retention" ||
+		key === "oauth.dynamic_client_max_count"
+	) {
+		if (typeof value !== "string" || value.trim() === "") {
+			return;
+		}
+		const numericValue = Number(value);
+		if (!Number.isFinite(numericValue)) {
+			return;
+		}
+		parsedValue = numericValue;
+	}
 
     try {
       const res = await updateSystemSettings({ [key]: parsedValue });


### PR DESCRIPTION
## Summary
- add the `oauth.dynamic_client_max_count` system setting to the admin OAuth section
- provide selectable quota values from 1,000 to 100,000 clients
- keep the setting persisted through the existing `system_settings` API
- update the OAuth guide with current PKCE, refresh-token rotation, response-format, redirect-URI, and state-handling guidance

Backend implementation: Lxns-Network/maimai-prober#85

## Validation
- `yarn build`
- `yarn lint` reports existing hook-dependency warnings outside this change
- `yarn format:check` reports existing formatting drift across the repository