### PR TITLE
fix(auth): update password validation policy

### DIFF
--- a/src/components/Settings/EditPasswordModal.tsx
+++ b/src/components/Settings/EditPasswordModal.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "@mantine/form";
-import { validatePassword } from "@/utils/validator.ts";
+import { validateExistingPassword, validateNewPassword } from "@/utils/validator.ts";
 import { useEditUserPassword } from "@/hooks/mutations/useUserMutations.ts";
 import { openRetryModal } from "@/utils/modal.tsx";
 import { notifications } from "@mantine/notifications";
@@ -24,10 +24,9 @@ export const EditPasswordModal = ({ opened, close }: { opened: boolean; close():
     },
 
     validate: {
-      current_password: (value) =>
-        validatePassword(value, { allowEmpty: false, passwordLabel: "原密码" }),
+      current_password: (value) => validateExistingPassword(value, { passwordLabel: "原密码" }),
       new_password: (value) =>
-        validatePassword(value, { allowEmpty: false, passwordLabel: "新密码" }),
+        validateNewPassword(value, { allowEmpty: false, passwordLabel: "新密码" }),
       confirm_new_password: (value, values) =>
         value === values.new_password ? null : "两次输入的新密码不一致",
     },

--- a/src/pages/public/Login.tsx
+++ b/src/pages/public/Login.tsx
@@ -17,7 +17,7 @@ import {
 import { Container } from "@mantine/core";
 import { solveCaptcha } from "@/utils/captcha";
 import { useForm } from "@mantine/form";
-import { validateEmail, validatePassword, validateUserName } from "@/utils/validator.ts";
+import { validateEmail, validateExistingPassword, validateUserName } from "@/utils/validator.ts";
 import { IconAlertCircle, IconLock, IconMail, IconUser } from "@tabler/icons-react";
 import classes from "../Form.module.css";
 import {
@@ -79,8 +79,9 @@ export default function Login() {
         }
       }
 
-      if (validatePassword(values.password, { allowEmpty: false })) {
-        errors.password = validatePassword(values.password, { allowEmpty: false });
+      const passwordError = validateExistingPassword(values.password);
+      if (passwordError) {
+        errors.password = passwordError;
       }
 
       return errors;

--- a/src/pages/public/Register.tsx
+++ b/src/pages/public/Register.tsx
@@ -13,7 +13,7 @@ import {
 import { Container } from "@mantine/core";
 import { solveCaptcha } from "@/utils/captcha";
 import { useForm } from "@mantine/form";
-import { validateEmail, validatePassword, validateUserName } from "@/utils/validator.ts";
+import { validateEmail, validateNewPassword, validateUserName } from "@/utils/validator.ts";
 import { IconLock, IconMail, IconUser } from "@tabler/icons-react";
 import classes from "../Form.module.css";
 import { openConfirmModal, openRetryModal } from "@/utils/modal.tsx";
@@ -43,7 +43,7 @@ export default function Register() {
     validate: {
       name: (value) => validateUserName(value, { allowEmpty: false }),
       email: (value) => validateEmail(value, { allowEmpty: false }),
-      password: (value) => validatePassword(value, { allowEmpty: false }),
+      password: (value) => validateNewPassword(value, { allowEmpty: false }),
       confirm_password: (value, values) =>
         value === values.password ? null : "两次输入的密码不一致",
     },

--- a/src/pages/public/ResetPassword.tsx
+++ b/src/pages/public/ResetPassword.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Title, Text, Group, Button, LoadingOverlay, PasswordInput, Card } from "@mantine/core";
 import { Container } from "@mantine/core";
-import { validatePassword } from "@/utils/validator.ts";
+import { validateNewPassword } from "@/utils/validator.ts";
 import { useForm } from "@mantine/form";
 import { IconLock } from "@tabler/icons-react";
 import classes from "../Form.module.css";
@@ -25,7 +25,7 @@ export default function ResetPassword() {
     if (!token) {
       navigate("/login", { overwriteLastHistoryEntry: true });
     }
-  }, []);
+  }, [token]);
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -34,7 +34,7 @@ export default function ResetPassword() {
     },
 
     validate: {
-      password: (value) => validatePassword(value, { allowEmpty: false }),
+      password: (value) => validateNewPassword(value, { allowEmpty: false }),
       confirm_password: (value, values) =>
         value === values.password ? null : "两次输入的密码不一致",
     },

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -29,7 +29,14 @@ export const validateUserName = (name: string, { allowEmpty = false }) => {
   return null;
 };
 
-export const validatePassword = (
+const newPasswordMinLength = 8;
+const newPasswordMaxLength = 18;
+
+export const validateExistingPassword = (password: string, { passwordLabel = "密码" } = {}) => {
+  return password.length === 0 ? `${passwordLabel}不能为空` : null;
+};
+
+export const validateNewPassword = (
   password: string,
   { allowEmpty = false, passwordLabel = "密码" },
 ) => {
@@ -38,8 +45,9 @@ export const validatePassword = (
   } else if (password.length === 0 && allowEmpty) {
     return null;
   }
-  if (password.length < 6 || password.length > 16) {
-    return `${passwordLabel}长度必须在 6 到 16 字符之间`;
+  const characterLength = Array.from(password).length;
+  if (characterLength < newPasswordMinLength || characterLength > newPasswordMaxLength) {
+    return `${passwordLabel}长度必须在 ${newPasswordMinLength} 到 ${newPasswordMaxLength} 字符之间`;
   }
   return null;
 };


### PR DESCRIPTION
## Summary
- validate newly chosen passwords as `8–18` Unicode characters
- keep login and current-password fields compatible with existing shorter passwords
- align registration, reset-password, and password-change forms with the backend policy
- avoid exposing byte-based hashing limits in user-facing validation

## Validation
- targeted `oxfmt --check`
- targeted ESLint with zero warnings
- `yarn tsc --noEmit`
- `yarn build`

The repository-wide lint command still reports the existing baseline of 67 warnings outside these changes.

Backend: Lxns-Network/maimai-prober#86