### PR TITLE
fix(scores): preserve chart details when switching difficulty

### DIFF
--- a/src/components/Scores/ScoreModal.tsx
+++ b/src/components/Scores/ScoreModal.tsx
@@ -123,7 +123,8 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
   });
   const commentCount = comments.length;
 
-  const { songDetail } = useSongDetail(game, score?.id ?? null);
+  const songId = score?.id ?? null;
+  const { songDetail } = useSongDetail(game, songId);
 
   useEffect(() => {
     setSongState(null);
@@ -155,12 +156,12 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
   }, [songState, score, songList]);
 
   useEffect(() => {
-    if (!score || !songList) {
+    if (songId === null || !songList) {
       setSongState(null);
       return;
     }
 
-    const song = songList.find(score.id);
+    const song = songList.find(songId);
     if (!song) {
       setSongState(null);
       return;
@@ -171,7 +172,7 @@ export const ScoreModal = ({ game, score, opened, onClose }: ScoreModalProps) =>
     } else if (game === "chunithm") {
       setSongState({ game: "chunithm", song: song as ChunithmSongProps });
     }
-  }, [score, songList, game]);
+  }, [songId, songList, game]);
 
   function isMaimaiScoreProps(obj: unknown): obj is MaimaiScoreProps {
     if (!obj) return false;


### PR DESCRIPTION
## 修改内容

- 同一首歌切换难度时保留已加载的完整曲目详情
- 避免曲目列表中的精简数据覆盖包含物量信息的详情数据
- 修复舞萌 DX 谱面详情持续加载以及中二节奏谱面详情消失的问题

## 根因

`ScoreModal` 会持续挂载。原本用于初始化曲目状态的 effect 依赖整个 `score` 对象，因此切换同一首歌的难度时会再次写入不含完整 `notes` 的曲目列表数据。与此同时，详情查询只按歌曲 ID 缓存；歌曲 ID 未变化时，已有详情数据不会触发另一次写回，最终导致谱面详情读取到缺失的物量数据。

本次将初始化 effect 的依赖收窄到歌曲 ID。同曲切换难度时继续使用已加载的完整详情，仅重新选择目标难度。

## 验证

- `yarn format:check`
- `yarn eslint src/components/Scores/ScoreModal.tsx --report-unused-disable-directives --max-warnings 0`
- `yarn build`

Closes #79