### PR TITLE
谱面预览适配 simai 特殊星星写法 @ 与 $ 修饰符顺序

### DIFF
--- a/packages/maimai-chart-engine/src/core/parser/SimaiParser.ts
+++ b/packages/maimai-chart-engine/src/core/parser/SimaiParser.ts
@@ -606,7 +606,7 @@ function parseNoteString(
   }
 
   // 尝试匹配滑条模式：1-5[4:1] 或 1b-5[4:1] 或复杂模式：1-4[8:5]>3[384:47]...
-  const slideMatch = noteStr.match(/^(\d+)([bx?!]*[-><^vpqszVw*]+.*)$/i);
+  const slideMatch = noteStr.match(/^(\d+)([bx?!@]*[-><^vpqszVw*]+.*)$/i);
   if (slideMatch && /[-><^vpqszVw]/i.test(slideMatch[2])) {
     const startPosition = parseInt(slideMatch[1]) as ButtonPosition;
     const slideNotation = slideMatch[2];
@@ -626,6 +626,8 @@ function parseNoteString(
       .otherwise(() => null);
     const isStartBreak = startModifiers.includes("b");
     const isHeadless = headlessMarker !== null;
+    // simai `@`：保留滑条头，但画成普通 TAP 而非星星头。
+    const hasTapHead = !isHeadless && startModifiers.includes("@");
     const isEx = noteStr.toLowerCase().includes("x");
 
     // 按 * 分割滑条
@@ -733,6 +735,7 @@ function parseNoteString(
           .with("?", () => "fade" as const)
           .with(null, () => undefined)
           .exhaustive(),
+        hasTapHead,
         isStartBreak,
         allSlideBreaks,
         isEx,
@@ -870,16 +873,16 @@ function parseNoteString(
     }
   }
 
-  // 尝试匹配简单按下/中断/星形 TAP：1, 1b, 1x, 1bx, 1$, 1$$
-  const tapMatch = noteStr.match(/^(\d+)([bx]*)(\${0,2})$/i);
+  // 尝试匹配简单按下/中断/星形 TAP：1, 1b, 1x, 1bx, 1$, 1$$；simai 修饰符顺序自由，`1$b` 等价于 `1b$`
+  const tapMatch = noteStr.match(/^(\d+)([bx$]*)$/i);
   if (tapMatch) {
     const position = parseInt(tapMatch[1]);
     const modifiers = tapMatch[2].toLowerCase();
-    const stars = tapMatch[3];
+    const starCount = modifiers.split("$").length - 1;
     const isBreak = modifiers.includes("b");
     const isEx = modifiers.includes("x");
-    const isStar = stars.length > 0;
-    const isSpinningStar = stars.length === 2;
+    const isStar = starCount > 0;
+    const isSpinningStar = starCount >= 2;
 
     if (position >= 1 && position <= 8) {
       const tapNote: TapNote = {

--- a/packages/maimai-chart-engine/src/renderers/MainRenderer.ts
+++ b/packages/maimai-chart-engine/src/renderers/MainRenderer.ts
@@ -974,7 +974,9 @@ export class MainRenderer {
             ? COLORS.BREAK_ORANGE
             : isSimultaneous
               ? COLORS.SIMULTANEOUS_GOLD
-              : COLORS.SLIDE_CYAN;
+              : note.hasTapHead
+                ? COLORS.TAP_PINK
+                : COLORS.SLIDE_CYAN;
         }
         if (!pos.visible) continue;
 
@@ -1107,37 +1109,55 @@ export class MainRenderer {
 
     const meta = this.getNoteMeta(noteMeta, slide);
     const isSimultaneous = meta.simultaneousNoteCount >= 2;
-    // 接近圈由 renderApproachIndicators 统一画（在底层），这里只画星星头。
-    const color = this.getStarHeadColor(slide.timing, slide.isStartBreak ?? false, isSimultaneous);
 
-    const rotation = this.config.slideRotation
-      ? this.slideRenderer.calculateStarRotation(slide, currentTimeMs)
-      : 0;
-
-    if (slide.isSplitSlide) {
-      const noteSize = this.getStarNoteSize(pos.scale);
-      if (slide.isEx) {
-        this.slideRenderer.renderExSplitStarRing(
-          pos.x,
-          pos.y,
-          noteSize,
-          slide.isStartBreak ?? false,
-          isSimultaneous,
-          this.exScale,
-        );
-      }
-      this.renderSplitSlideStar(pos.x, pos.y, noteSize, color, rotation, slide.isEx ?? false);
-    } else {
-      this.renderStarHead(
+    // 接近圈由 renderApproachIndicators 统一画（在底层），这里只画滑条头。
+    if (slide.hasTapHead) {
+      this.noteRenderer.renderTapNote(
         pos.x,
         pos.y,
         pos.scale,
-        color,
-        rotation,
+        slide.position,
+        slide.isStartBreak ?? false,
+        isSimultaneous,
         slide.isEx ?? false,
+        slide.timing,
+        this.exScale,
+      );
+    } else {
+      const color = this.getStarHeadColor(
+        slide.timing,
         slide.isStartBreak ?? false,
         isSimultaneous,
       );
+      const rotation = this.config.slideRotation
+        ? this.slideRenderer.calculateStarRotation(slide, currentTimeMs)
+        : 0;
+
+      if (slide.isSplitSlide) {
+        const noteSize = this.getStarNoteSize(pos.scale);
+        if (slide.isEx) {
+          this.slideRenderer.renderExSplitStarRing(
+            pos.x,
+            pos.y,
+            noteSize,
+            slide.isStartBreak ?? false,
+            isSimultaneous,
+            this.exScale,
+          );
+        }
+        this.renderSplitSlideStar(pos.x, pos.y, noteSize, color, rotation, slide.isEx ?? false);
+      } else {
+        this.renderStarHead(
+          pos.x,
+          pos.y,
+          pos.scale,
+          color,
+          rotation,
+          slide.isEx ?? false,
+          slide.isStartBreak ?? false,
+          isSimultaneous,
+        );
+      }
     }
 
     if (this.config.showBreakIndex && slide.isStartBreak && meta.noExBreakIndex && !slide.isEx) {

--- a/packages/maimai-chart-engine/src/types/index.ts
+++ b/packages/maimai-chart-engine/src/types/index.ts
@@ -214,6 +214,8 @@ export interface SlideNote extends BaseNote {
   isHeadless?: boolean;
   /** 无头滑条 tracing star 显示方式：simai `?` 为 fade，`!` 为 pop */
   headlessMode?: "fade" | "pop";
+  /** 滑条头是否画成普通 TAP 而非星星头（simai `@`）；isHeadless 时无意义 */
+  hasTapHead?: boolean;
   /** 滑条起始 Note 是否为绝赞 */
   isStartBreak?: boolean;
   /** 每个滑条路径是否为绝赞 */


### PR DESCRIPTION
- 滑条头修饰符支持 `@`：保留滑条头但画成普通 TAP 而非星星头，接近圈同步改用 TAP 配色
- TAP 修饰符顺序不再受限，`1$b` / `1$x` / `1$bx` 与 `1b$` / `1x$` 等价

此前两类写法都匹配不到任何分支而被整条丢弃，宴谱里共 419 处 note（含
[星]しゅわスパ大作戦☆ 的 115 note、全部 34 个绝赞）不会出现在预览中。