### PR TITLE
feat(ops): publish the frontend build as a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      # FRONTEND_VERSION lands in dist/client/version.json, which the running site serves
+      # and useVersionChecker polls, so the tag is what identifies the live build.
+      - name: Build
+        env:
+          FRONTEND_VERSION: ${{ steps.version.outputs.VERSION }}
+        run: yarn build
+
+      - name: Verify the stamp
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          got=$(node -e "process.stdout.write(require('./dist/client/version.json').version)")
+          if [ "$got" != "$VERSION" ]; then
+            echo "version.json says '$got', expected '$VERSION'" >&2
+            exit 1
+          fi
+
+      # Only dist/client is served; dist/server is the SSR half and the deployed site does
+      # not use it. Packaged with the directory as the root so it unpacks over dist/client.
+      - name: Package
+        run: |
+          mkdir -p build
+          tar -czf build/dist-client.tar.gz -C dist/client .
+          cd build && sha256sum dist-client.tar.gz > dist-client.tar.gz.sha256
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/dist-client.tar.gz
+            build/dist-client.tar.gz.sha256
+          tag_name: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # DEPLOY_REPO_SSH_KEY is a write deploy key on Lxns-Network/maimai-prober-deploy,
+      # separate from the backend's so either can be revoked alone.
+      - name: Pin the version in the deploy repository
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_REPO_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes"
+          git clone --depth 1 git@github.com:Lxns-Network/maimai-prober-deploy.git deploy
+          cd deploy
+          echo "$VERSION" > VERSIONS/frontend
+          if git diff --quiet; then
+            echo "already pinned to $VERSION"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "deploy(frontend): $VERSION"
+          git push

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,9 @@ function generateVersionPlugin(): Plugin {
       projectRoot = config.root;
     },
     closeBundle() {
-      const version = Date.now().toString();
+      // A release stamps its tag here so /version.json names the build that is live, the
+      // way /api/v0/health does for the backend. Local builds keep the timestamp.
+      const version = process.env.FRONTEND_VERSION || Date.now().toString();
       const outputPath = path.resolve(projectRoot, "dist/client/version.json");
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
       fs.writeFileSync(outputPath, JSON.stringify({ version }));


### PR DESCRIPTION
## Why

`ci.yml` already runs `yarn build` on every push — and throws the result away. Deploying the frontend therefore meant building on a workstation, and it shows: `dist/client` on the server was last written **6 August**, while the backend shipped repeatedly since.

## What

**`release.yml`** — on a `v*` tag:

| step | |
|---|---|
| build | `yarn build` with `FRONTEND_VERSION` set to the tag |
| verify | `dist/client/version.json` must contain the tag, or the job fails |
| package | `dist-client.tar.gz` + `sha256` |
| pin | writes `VERSIONS/frontend` in `maimai-prober-deploy` |

Only `dist/client` is packaged. `dist/server` is the Vike SSR half and the deployed site never reads it — the Go server serves `frontend.dist: ./dist/client` as static files.

**`version.json` carries the tag.** It previously used `Date.now()`. `useVersionChecker` only compares the string for inequality, so a tag works, and it buys two things:

- `curl https://maimai.lxns.net/version.json` names the live frontend — the parity with `/api/v0/health` that made yesterday's "which build is running?" question answerable at all
- a rebuild of unchanged content no longer differs, so it stops prompting every open page to reload for nothing

Local builds keep the timestamp, so `yarn dev` and `yarn build` behave exactly as before.

The verify step exists for the same reason as the backend's: a stamp that silently didn't apply would leave `version.json` back on timestamps, and the deploy unable to tell builds apart.

## Credentials

`DEPLOY_REPO_SSH_KEY` here is a **separate** write deploy key (id `161074803`) on `maimai-prober-deploy`, distinct from the backend's `160977162`, so either can be revoked without affecting the other. Already configured.

## Scope

This publishes; it does not deploy. Getting `dist/client` onto the server is still manual, and shares the pull-side timer still to be built with the backend. Both halves land on one `systemctl reload` — the Go server binds its `dist/client` handle with `os.OpenRoot` at startup, so a frontend swap needs a reload to take effect, the same one the binary needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)