### PR TITLE
feat(ci): deploy the release to the server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "deploy(frontend): $VERSION"
           git push
+
+      # The key this uses is pinned to receive.sh by authorized_keys, so it can ask for a
+      # deploy and nothing else — not a shell, not scp. The artifact goes over stdin and the
+      # checksum is verified on the far side before anything is staged.
+      - name: Deploy
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_ssh_key
+          chmod 600 ~/.ssh/deploy_ssh_key
+          ssh-keyscan -t ed25519 "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          sum=$(cut -d' ' -f1 build/dist-client.tar.gz.sha256)
+          ssh -i ~/.ssh/deploy_ssh_key -o IdentitiesOnly=yes -o BatchMode=yes             "ubuntu@${DEPLOY_HOST}" "deploy frontend ${VERSION} ${sum}" < build/dist-client.tar.gz


### PR DESCRIPTION
Tagging built, published and pinned the frontend, then stopped — the tarball still had to be fetched, unpacked and swapped by hand. That is why `dist/client` on the server sat two and a half weeks behind while the backend shipped repeatedly.

## What CI now does

```
ssh -i <key> ubuntu@$DEPLOY_HOST "deploy frontend $VERSION $sha256" < build/dist-client.tar.gz
```

## What that key can do

Nothing else. `authorized_keys` pins it to `receive.sh`:

```
restrict,command="/home/ubuntu/maimai-prober/receive.sh" ssh-ed25519 AAAA...
```

Verified against the installed key: an arbitrary command is refused, no command gives no shell, and `scp` gets `Connection closed`. A forced command blocking scp is *why* the tarball travels on stdin.

## What the far side checks

`receive.sh` (in [maimai-prober-deploy](https://github.com/Lxns-Network/maimai-prober-deploy)) whitelists the request, verifies the checksum, unpacks to `dist/client.new`, and requires `version.json` to name the version it was sent as — so the build that gets deployed is one the health check can later confirm.

`deploy.sh` then swaps it and reloads once. That reload is also what republishes the binary, since the Go server binds its `dist/client` handle with `os.OpenRoot` at startup, so there is no window where a new frontend talks to an old API. If `/version.json` does not come back with the new version, the previous build goes back.

## Verified end to end

A real `dist-client.tar.gz` went through the installed key to a confirmed deploy of `v1.0.0` — the same path this workflow will take.

## Note

`DEPLOY_HOST` is a repository variable; the key is `DEPLOY_SSH_KEY`. Both are already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)